### PR TITLE
Multithreading

### DIFF
--- a/src/runtime/ccompiler.cc
+++ b/src/runtime/ccompiler.cc
@@ -22,16 +22,19 @@ using namespace std;
 using namespace clang;
 using namespace llvm;
 
-string c_to_elf( const string_view c_content,
-                 const string_view h_content,
-                 const string_view fixpoint_header,
-                 const string_view wasm_rt_content )
+void llvm_init()
 {
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmPrinters();
   llvm::InitializeAllAsmParsers();
+}
 
+string c_to_elf( const string_view c_content,
+                 const string_view h_content,
+                 const string_view fixpoint_header,
+                 const string_view wasm_rt_content )
+{
   // Create compiler instance
   clang::CompilerInstance compilerInstance;
 

--- a/src/runtime/ccompiler.hh
+++ b/src/runtime/ccompiler.hh
@@ -1,5 +1,7 @@
 #include <string>
 
+void llvm_init();
+
 std::string c_to_elf( const std::string_view c_content,
                       const std::string_view h_content,
                       const std::string_view fixpoint_header,

--- a/src/runtime/fixpointapi.cc
+++ b/src/runtime/fixpointapi.cc
@@ -22,7 +22,7 @@ void attach_blob( __m256i ro_handle, wasm_rt_memory_t* target_memory )
   GlobalScopeTimer<Timer::Category::AttachBlob> record_timer;
   ObjectReference obj( ro_handle );
   if ( obj.get_content_type() != ContentType::Blob || !obj.is_accessible() ) {
-    throw std::runtime_error( "not an accssible blob" );
+    throw std::runtime_error( "not an accessible blob" );
   }
 
   std::string_view blob;

--- a/src/storage/concurrent_flat_hash_map.hh
+++ b/src/storage/concurrent_flat_hash_map.hh
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "absl/container/flat_hash_map.h"
+#include "name.hh"
+
+template<typename T>
+class concurrent_flat_hash_map
+{
+private:
+  absl::flat_hash_map<Name, T, NameHash> flat_hash_map_;
+  std::mutex flat_hash_map_mutex_;
+
+public:
+  concurrent_flat_hash_map()
+    : flat_hash_map_()
+    , flat_hash_map_mutex_()
+  {}
+
+  T& at( Name name )
+  {
+    std::lock_guard<std::mutex> lock( flat_hash_map_mutex_ );
+    return flat_hash_map_.at( name );
+  }
+
+  bool contains( const Name name )
+  {
+    std::lock_guard<std::mutex> lock( flat_hash_map_mutex_ );
+    return flat_hash_map_.contains( name );
+  }
+
+  void insert_or_assign( const Name name, const T& value )
+  {
+    std::lock_guard<std::mutex> lock( flat_hash_map_mutex_ );
+    flat_hash_map_.insert_or_assign( name, std::move( value ) );
+  }
+
+  void insert_or_assign( const Name name, T&& value )
+  {
+    std::lock_guard<std::mutex> lock( flat_hash_map_mutex_ );
+    flat_hash_map_.insert_or_assign( name, std::move( value ) );
+  }
+};

--- a/src/storage/concurrent_queue.hh
+++ b/src/storage/concurrent_queue.hh
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <queue>
+
+template<typename T>
+class concurrent_queue
+{
+private:
+  std::queue<T> queue_;
+  std::mutex queue_mutex_;
+
+public:
+  concurrent_queue()
+    : queue_()
+    , queue_mutex_()
+  {}
+
+  void push( const T& value )
+  {
+    std::lock_guard<std::mutex> lock( queue_mutex_ );
+    queue_.push( std::move( value ) );
+  }
+
+  bool front_pop( T& value )
+  {
+    std::lock_guard<std::mutex> lock( queue_mutex_ );
+    if ( queue_.empty() )
+      return false;
+    value = queue_.front();
+    queue_.pop();
+    return true;
+  }
+
+  bool empty()
+  {
+    std::lock_guard<std::mutex> lock( queue_mutex_ );
+    return queue_.empty();
+  }
+};

--- a/src/storage/concurrent_vector.hh
+++ b/src/storage/concurrent_vector.hh
@@ -1,0 +1,37 @@
+template<typename T>
+class concurrent_vector
+{
+private:
+  std::vector<T> vector_;
+  std::mutex vector_mutex_;
+
+public:
+  concurrent_vector()
+    : vector_()
+    , vector_mutex_()
+  {}
+
+  T& at( const std::vector<T>::size_type pos )
+  {
+    std::lock_guard<std::mutex> lock( vector_mutex_ );
+    return vector_.at( pos );
+  }
+
+  std::vector<T>::size_type size()
+  {
+    std::lock_guard<std::mutex> lock( vector_mutex_ );
+    return vector_.size();
+  }
+
+  void push_back( const T& value )
+  {
+    std::lock_guard<std::mutex> lock( vector_mutex_ );
+    vector_.push_back( std::move( value ) );
+  }
+
+  void push_back( T&& value )
+  {
+    std::lock_guard<std::mutex> lock( vector_mutex_ );
+    vector_.push_back( std::move( value ) );
+  }
+};


### PR DESCRIPTION
Memoization and program cache entries were previously dependent on a local name which made it impossible to cache previous compilations or identical sub-trees within the execution of a thunk. This commit defines a local to canonical name translation which is then used within the memoization and name to program caches.  