### PR TITLE
add grow table functions to library_func_map in elfloader.cc

### DIFF
--- a/src/runtime/elfloader.cc
+++ b/src/runtime/elfloader.cc
@@ -29,6 +29,8 @@ const static map<string, uint64_t> library_func_map
       { "wasm_rt_free_memory_sw_checked", (uint64_t)wasm_rt_free_memory_sw_checked },
       { "wasm_rt_free_funcref_table", (uint64_t)wasm_rt_free_funcref_table },
       { "wasm_rt_free_externref_table", (uint64_t)wasm_rt_free_externref_table },
+      { "wasm_rt_grow_funcref_table", (uint64_t)wasm_rt_grow_funcref_table },
+      { "wasm_rt_grow_externref_table", (uint64_t)wasm_rt_grow_externref_table },
       { "wasm_rt_init", (uint64_t)wasm_rt_init },
       { "wasm_rt_free", (uint64_t)wasm_rt_free },
       { "wasm_rt_is_initialized", (uint64_t)wasm_rt_is_initialized },


### PR DESCRIPTION
## Changes
Currently, when table.grow is called, elfloader.cc throws and error on line 199:

`can't find function wasm_rt_grow_externref_table`

This fix adds wasm_rt_grow_externref_table and wasm_rt_grow_funcref_table to library_func_map.

## Testing

1) created a wat file that creates a externref table, and exposes a grow_table function that calls table.grow
2) created a c file that imports grow_table and implements _fixpoint_apply
3) compile and link files
4) error "can't find function" is no longer raised