### PR TITLE
Canonical Names

### DIFF
--- a/src/component/name.hh
+++ b/src/component/name.hh
@@ -46,6 +46,14 @@ public:
     content_[2] = size;
   }
 
+  Name( std::string hash, size_t size, const uint8_t metadata )
+  {
+    assert( hash.size() == 32 );
+    hash[31] = static_cast<char>( 0x04 | metadata );
+    __builtin_memcpy( &content_, hash.data(), 32 );
+    content_[2] = size;
+  }
+
   Name( std::string_view literal_content )
   {
     assert( literal_content.size() < 32 );
@@ -65,6 +73,8 @@ public:
   size_t get_local_id() const { return _mm256_extract_epi64( content_, 0 ); };
 
   bool is_strict_tree_entry() const { return !( metadata() & 0x80 ); }
+
+  uint8_t get_metadata() { return metadata(); }
 
   static Name name_only( Name name )
   {


### PR DESCRIPTION
Yuhan—I know you brought up some initial concerns about whether the canonical name should be used by the local_to_storage conversion. Particularly, your concern was around whether the strict/lazy bits should be accounted for in computing the canonical name? From my conversation with Keith, it sounds like the strict/lazy bits probably should not be part of the metadata in the first case and this should be included in the runtime information stored as the first entry in the encode tree. That should be addressed in a separate commit. 

This commit at least enables me to have a canonical name that can be used for caching program compilations so I can better test the multithreaded runtime. Eventually, when "evaluate_encode" is removed, the memoization cache will fill this place and a separate set of bits within the first entry of the encode tree should be set to determine when canonical names should be computed, and that will be up to the user.