### PR TITLE
Remove pool of wasm modules

### DIFF
--- a/src/runtime/elfloader.cc
+++ b/src/runtime/elfloader.cc
@@ -234,11 +234,5 @@ Program link_program( const string_view program_content )
 #if TIME_FIXPOINT == 2
   global_timer().stop<Timer::Category::Linking>();
 #endif
-  return Program( code,
-                  init_entry,
-                  main_entry,
-                  cleanup_entry,
-                  instance_size_entry,
-                  init_module_entry,
-                  RuntimeStorage::get_instance().get_init_instances() );
+  return Program( code, init_entry, main_entry, cleanup_entry, instance_size_entry, init_module_entry );
 }

--- a/src/runtime/runtimestorage.hh
+++ b/src/runtime/runtimestorage.hh
@@ -36,9 +36,6 @@ private:
   // Storage for Object/Names with a local name
   std::vector<ObjectOrName> local_storage_;
 
-  // Number of instances
-  size_t init_instances_;
-
   RuntimeStorage()
     : storage()
     , memoization_cache()
@@ -46,7 +43,6 @@ private:
     , name_to_program_()
     , next_local_name_( 0 )
     , local_storage_()
-    , init_instances_( 16 )
   {
     wasm_rt_init();
   }
@@ -92,9 +88,6 @@ public:
 
   // Evaluate an encode
   Name evaluate_encode( Name encode_name );
-
-  void set_init_instances( size_t init_instances ) { init_instances_ = init_instances; }
-  size_t get_init_instances() const { return init_instances_; }
 
   // Populate a program
   void populate_program( Name function_name );

--- a/src/tester/add_timing.cc
+++ b/src/tester/add_timing.cc
@@ -36,7 +36,6 @@ int main( int argc, char* argv[] )
 
   ReadOnlyFile wasm_content { argv[1] };
 
-  runtime.set_init_instances( INIT_INSTANCE );
   Name add_name = runtime.add_blob( string_view( wasm_content ) );
   runtime.populate_program( add_name );
 

--- a/src/tester/benchmark_timing.cc
+++ b/src/tester/benchmark_timing.cc
@@ -81,8 +81,6 @@ int main( int argc, char* argv[] )
          << " path_to_add_program path_to_add_cycle_program path_to_add_fixpoint path_to_add_wasi\n";
   }
 
-  runtime.set_init_instances( INIT_INSTANCE );
-
   add_program_name = argv[1];
   add_cycle_program_name = argv[2];
 

--- a/src/tester/benchmark_timing_perf.cc
+++ b/src/tester/benchmark_timing_perf.cc
@@ -45,7 +45,6 @@ int main( int argc, char* argv[] )
     cerr << "Usage: " << argv[0] << " path_to_add_fixpoint\n";
   }
   global_timer().start<Timer::Category::Execution>();
-  runtime.set_init_instances( INIT_INSTANCE );
 
   ReadOnlyFile add_fixpoint_content { argv[1] };
   Name add_fixpoint_function = runtime.add_blob( string_view( add_fixpoint_content ) );

--- a/src/tester/step_timing.cc
+++ b/src/tester/step_timing.cc
@@ -45,8 +45,6 @@ int main( int argc, char* argv[] )
     cerr << "Usage: " << argv[0] << " path_to_add_fixpoint path_to_add_wasi\n";
   }
 
-  runtime.set_init_instances( INIT_INSTANCE );
-
   ReadOnlyFile add_fixpoint_content { argv[1] };
   ReadOnlyFile add_wasi_content { argv[2] };
 


### PR DESCRIPTION
From our discussions, it sounds like having an on-hand pool of available modules for each `Program` does not significantly benefit performance (and may even make it worse?). This commit modifies the program to generate the module instance on execution, every execution. 

If there were a significant benefit to keeping a pool of instances available, I could work on techniques to monitor/replenish them. But otherwise, this seems to be the simplest path forward, and allows for easier testing of the multi-threaded runtime. 