### PR TITLE
grow table segfault fix

### DIFF
--- a/pl/CMakeLists.txt
+++ b/pl/CMakeLists.txt
@@ -14,10 +14,10 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(wasm-tools)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -nostdlib -mreference-types -I ~/wasm-toolchain/wasix/include")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -mreference-types -I ~/wasm-toolchain/wasix/include -fno-exceptions")
 set(CMAKE_CXX_COMPILER $ENV{HOME}/wasm-toolchain/sysroot/bin/clang++)
 
-add_link_options( -nostdlib -Wl,--no-entry -Wl,--allow-undefined, -Wl, -Werror, -Wunused-parameter)
+add_link_options( -Wl,--no-entry -Wl,--allow-undefined, -Wl, -Werror, -Wunused-parameter, -fno-exceptions)
 
 add_library(add_2_obj OBJECT "add_2.cc")
 
@@ -28,6 +28,9 @@ add_custom_command(
   COMMAND $ENV{HOME}/wasm-toolchain/sysroot/bin/wasm-ld
           ${CMAKE_BINARY_DIR}/CMakeFiles/add_2_obj.dir/add_2.cc.o
           $ENV{HOME}/wasm-toolchain/sysroot/lib/wasm32-wasi/libc++.a
+          $ENV{HOME}/wasm-toolchain/sysroot/lib/wasm32-wasi/libc.a
+          $ENV{HOME}/wasm-toolchain/sysroot/lib/clang/16.0.0/lib/wasi/libclang_rt.builtins-wasm32.a
+          $ENV{HOME}/wasm-toolchain/sysroot/lib/wasm32-wasi/libc++abi.a
           -o add_2.wasm
           --no-entry
           --allow-undefined
@@ -44,7 +47,17 @@ add_custom_command(
 )
 
 add_custom_command(
-    OUTPUT "add_2_map.wasm"
+  OUTPUT "wasi_snapshot_preview1.wasm"
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/map_memory.wat
+  COMMAND ${CMAKE_BINARY_DIR}/../../../_deps/wabt-build/wat2wasm
+          --enable-multi-memory
+	        --enable-exceptions
+          ${CMAKE_CURRENT_SOURCE_DIR}/wasi_snapshot_preview1.wat
+          -o wasi_snapshot_preview1.wasm
+)
+
+add_custom_command(
+    OUTPUT "tmp.wasm"
     DEPENDS ${CMAKE_BINARY_DIR}/_deps/wasm-tools-build/src/module-combiner/wasmlink
     add_2.wasm
     map_memory.wasm
@@ -53,13 +66,28 @@ add_custom_command(
     --enable-exceptions
     add_2.wasm
     map_memory.wasm
+    -o tmp.wasm
+)
+
+add_custom_command(
+    OUTPUT "add_2_map.wasm"
+    DEPENDS ${CMAKE_BINARY_DIR}/_deps/wasm-tools-build/src/module-combiner/wasmlink
+    tmp.wasm
+    wasi_snapshot_preview1.wasm
+    COMMAND ${CMAKE_BINARY_DIR}/_deps/wasm-tools-build/src/module-combiner/wasmlink
+    --enable-multi-memory
+    --enable-exceptions
+    tmp.wasm
+    wasi_snapshot_preview1.wasm
     -o add_2_map.wasm
-    )
+)
 
 add_custom_target(
         pl-test ALL
         DEPENDS add_2.wasm
                 map_memory.wasm
+                wasi_snapshot_preview1.wasm
+                tmp.wasm
                 add_2_map.wasm
       )
   

--- a/pl/map.cc
+++ b/pl/map.cc
@@ -1,5 +1,4 @@
 #include <cstdint>
-#include <string>
 
 typedef char __attribute__( ( address_space( 10 ) ) ) * externref;
 
@@ -49,7 +48,10 @@ externref create_thunk( externref pointer )
 // value in the encode and arg_1 as the fifth.
 externref map( externref resource_limits, externref main_blob, uint32_t arr[], uint32_t arr_size, uint32_t arg_1 )
 {
-  grow_rw_table_1( arr_size, resource_limits );
+  int32_t old_size = grow_rw_table_1( arr_size, resource_limits );
+  if ( old_size == -1 ) {
+    return resource_limits;
+  }
 
   externref arg_blob = create_blob_i32( arg_1 );
   for ( int i = 0; i < arr_size; i++ ) {
@@ -58,7 +60,10 @@ externref map( externref resource_limits, externref main_blob, uint32_t arr[], u
     set_rw_table_0( 2, arg_blob );
     set_rw_table_0( 3, create_blob_i32( arr[i] ) );
     set_rw_table_1( i, create_thunk( create_tree_rw_table_0( 4 ) ) );
-    grow_rw_table_0( 4, resource_limits );
+    old_size = grow_rw_table_0( 4, resource_limits );
+    if ( old_size == -1 ) {
+      return resource_limits;
+    }
   }
   return create_tree_rw_table_1( arr_size );
 }

--- a/pl/map_memory.wat
+++ b/pl/map_memory.wat
@@ -28,14 +28,14 @@
   )
 
   ;; Grows rw_table_1 by $size and initializes new values to $init_val. 
-  ;; Returns the old length.
+  ;; Returns the old length or -1 for failure.
   (func (export "grow_rw_table_1") (param $size i32) (param $init_val externref ) (result i32)
     (local.get $init_val)
     (local.get $size)
     (table.grow $rw_table_1)
   )
 
-  ;; Grows rw_mem_0 by $size and returns the old length.
+  ;; Grows rw_mem_0 by $size and returns the old length or -1 for failure.
   (func (export "grow_rw_mem_0") (param $size i32) (result i32)
     (local.get $size)
     (memory.grow $rw_mem_0)

--- a/pl/wasi_snapshot_preview1.wat
+++ b/pl/wasi_snapshot_preview1.wat
@@ -1,0 +1,17 @@
+;; This module provides stubs for stdio functions that are needed for wasm-toolchain/sysroot/lib/wasm32-wasi/libc++abi.a
+
+
+(module
+  (func (export "fd_close") (param i32) (result i32)
+    unreachable
+  )
+
+  (func (export "fd_write") (param i32 i32 i32 i32) (result i32)
+    unreachable
+  )
+
+  (func (export "fd_seek") (param i32 i64 i32 i32) (result i32)
+    unreachable
+  )
+
+)

--- a/src/wasm-rt/wasm-rt-impl.cc
+++ b/src/wasm-rt/wasm-rt-impl.cc
@@ -442,24 +442,24 @@ void wasm_rt_free_memory( wasm_rt_memory_t* memory )
   }                                                                                                                \
   uint32_t wasm_rt_grow_##type##_table( wasm_rt_##type##_table_t* table, uint32_t delta, wasm_rt_##type##_t init ) \
   {                                                                                                                \
-    uint32_t old_elems = table->size;                                                                              \
-    uint64_t new_elems = (uint64_t)table->size + delta;                                                            \
-    if ( new_elems == 0 ) {                                                                                        \
+    uint32_t old_length = table->size;                                                                             \
+    wasm_rt_##type##_t* old_data = table->data;                                                                    \
+    uint64_t new_length = (uint64_t)table->size + delta;                                                           \
+    if ( new_length == 0 ) {                                                                                       \
       return 0;                                                                                                    \
     }                                                                                                              \
-    if ( ( new_elems < old_elems ) || ( new_elems > table->max_size ) ) {                                          \
+    if ( ( new_length < old_length ) || ( new_length > table->max_size ) ) {                                       \
       return (uint32_t)-1;                                                                                         \
     }                                                                                                              \
-    void* new_data = realloc( table->data, new_elems * sizeof( wasm_rt_##type##_t ) );                             \
-    if ( !new_data ) {                                                                                             \
-      return (uint32_t)-1;                                                                                         \
-    }                                                                                                              \
-    table->data = static_cast<wasm_rt_##type##_t*>( new_data );                                                    \
-    table->size = new_elems;                                                                                       \
-    for ( uint32_t i = old_elems; i < new_elems; i++ ) {                                                           \
+    void* ptr = aligned_alloc( alignof( wasm_rt_##type##_t ), new_length * sizeof( wasm_rt_##type##_t ) );         \
+    table->data = static_cast<wasm_rt_##type##_t*>( ptr );                                                         \
+    memcpy( table->data, old_data, old_length * sizeof( wasm_rt_##type##_t ) );                                    \
+    table->size = new_length;                                                                                      \
+    for ( uint32_t i = old_length; i < new_length; i++ ) {                                                         \
       table->data[i] = init;                                                                                       \
     }                                                                                                              \
-    return old_elems;                                                                                              \
+    free( old_data );                                                                                              \
+    return old_length;                                                                                             \
   }
 
 DEFINE_TABLE_OPS( funcref )


### PR DESCRIPTION
## Changes
 Major change:
- fixes the grow table segfault by using aligned_alloc instead of realloc. I'm honestly not sure why this works but it fixes the segfault and removes all valgrind memory leaks. Maybe someone has an idea?

Minor changes:
- implement a dummy fd_close/fd_write/fd_seek so `add_2.cc` can import and use c++ libraries such as string
- update the docstring of grow_table
- check that grow_table succeeds before continuing with map.


## Testing
ran map using the stateless tester -> no segfaults 