### PR TITLE
Add working trap test (and abort for SEGV outside Wasm execution)

### DIFF
--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -56,9 +56,10 @@ add_test(NAME t_add_args WORKING_DIRECTORY
   ${CMAKE_CURRENT_BINARY_DIR}/src/tester/stateless-tester
   ${CMAKE_CURRENT_BINARY_DIR}/flatware-prefix/src/flatware-build/examples/add/add-fixpoint.wasm
 )
-# XXX we don't catch the trap yet
-#add_test(NAME t_trap WORKING_DIRECTORY
-#  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tester/stateless-tester
-#  tree:2 string:ignored
-#  "file:${CMAKE_CURRENT_BINARY_DIR}/testing/wasm-examples/trap.wasm"
-#)
+
+add_test(NAME t_trap WORKING_DIRECTORY
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/testing/expect-trap
+  ${CMAKE_CURRENT_BINARY_DIR}/src/tester/stateless-tester
+  ${CMAKE_CURRENT_BINARY_DIR}/testing/wasm-examples/trap.wasm
+  "Integer divide by zero"
+)

--- a/testing/expect-trap
+++ b/testing/expect-trap
@@ -1,0 +1,35 @@
+#!/usr/bin/perl -w
+
+use strict;
+
+if ((scalar @ARGV) != 3) {
+  die qq{Usage: $0 stateless-tester trap.wasm expected_trap_name};
+}
+
+my ($executable, $trap_wasm, $expected_trap_name) = @ARGV;
+
+open (my $command, '-|', qq{$executable tree:2 string:unused file:${trap_wasm} 2>&1}) or die qq{$!};
+
+my $found_trap = 0;
+my @output;
+while (<$command>) {
+  chomp;
+  push @output, $_;
+  if (m{Execution trapped: ${expected_trap_name}$}) {
+    $found_trap = 1;
+  }
+}
+
+close($command) and die qq{Execution did not trap as expected: $!};
+
+if ($found_trap) {
+  print STDERR qq{Execution trapped as expected.\n};
+  exit 0;
+}
+
+print STDERR "Execution trapped, but not as expected. Output was:\n";
+for (@output) {
+  print qq{   $_\n};
+}
+
+die qq{Execution did not trap as expected};


### PR DESCRIPTION
This adds a Wasm procedure that intentionally traps, and makes sure that it does (without crashing Fixpoint).

The runtime (including trap handling) isn't thread-safe yet -- we'll need to take the recent changes to upstream wasm2c, which includes the addition of `thread_local` to some of these globals as well as the new wasm2c-time generation of Func types (and elimination of the global Func types registry).