### PR TITLE
replace get_parent_map with single query get_parents

### DIFF
--- a/src/runtime/runtimestorage.hh
+++ b/src/runtime/runtimestorage.hh
@@ -174,10 +174,6 @@ public:
 
   Handle get_local_handle( Handle canonical ) { return canonical_to_local_.at( canonical ); }
 
-  // Get the parent map of handle to tasks that produced handle. Potentially expensive operation
-  // Linear in size of fixcache
-  absl::flat_hash_map<Handle, std::vector<Task>, absl::Hash<Handle>> get_parent_map()
-  {
-    return fix_cache_.get_parent_map();
-  }
+  // Get the tasks that produced a handle. Linear time in size of fixcache
+  std::vector<Task> get_parents( Handle child ) { return fix_cache_.get_parents( child ); }
 };

--- a/src/storage/fixcache.hh
+++ b/src/storage/fixcache.hh
@@ -321,25 +321,20 @@ public:
   }
 
   /**
-   * Creates a map from Handle to all possible Tasks that created that Handle.
+   * Search for all possible Tasks that created a Handle.
    *
    * Time complexity grows linearly with the size of fixcache_.
    *
-   * @return  A map from all Handles (results of computations) to Tasks that may
-   *          have created them.
+   * @return  A vector of Tasks that could have created this Handle.
    */
-  absl::flat_hash_map<Handle, std::vector<Task>, absl::Hash<Handle>> get_parent_map()
+  std::vector<Task> get_parents( Handle child )
   {
     std::shared_lock lock( fixcache_mutex_ );
-    absl::flat_hash_map<Handle, std::vector<Task>, absl::Hash<Handle>> result = {};
+    std::vector<Task> result = {};
 
     for ( auto& [task, handle] : fixcache_ ) {
-      if ( handle.has_value() ) {
-        Handle value = handle.value();
-        if ( !result.contains( value ) ) {
-          result.insert( { value, {} } );
-        }
-        result.at( value ).push_back( task );
+      if ( handle.has_value() and handle.value() == child ) {
+        result.push_back( task );
       }
     }
 

--- a/src/tester/dependency-tester.cc
+++ b/src/tester/dependency-tester.cc
@@ -108,8 +108,6 @@ void program_body( span_view<char*> args )
   cout << "Result handle: " << result << endl;
   cout << endl;
 
-  absl::flat_hash_map<Handle, std::vector<Task>, absl::Hash<Handle>> parent_map = runtime.get_parent_map();
-
   while ( true ) {
     cout << "Enter [parents(p)|content(c)|dependees(d)] and a local id or handle in form ab|cd|ef|01 (empty to "
             "quit):"
@@ -135,12 +133,8 @@ void program_body( span_view<char*> args )
         cout << "Could not parse handle (parents command must take a handle)." << endl;
         continue;
       }
-      if ( !parent_map.contains( input.value() ) ) {
-        cout << "Could not find handle in parent_map" << endl;
-        continue;
-      }
       cout << "[\n";
-      for ( auto& task : parent_map.at( input.value() ) ) {
+      for ( auto& task : runtime.get_parents( input.value() ) ) {
         cout << "  " << task << ",\n";
       }
       cout << "]\n";


### PR DESCRIPTION
simplifies api by doing a linear scan for individual queries rather than creating a temporary hash map that may go out of date