### PR TITLE
Switch concurrent queue implementation to one with move semantics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third-party/PicoSHA2"]
 	path = third-party/PicoSHA2
 	url = https://github.com/okdshin/PicoSHA2
+[submodule "third-party/concurrentqueue"]
+	path = third-party/concurrentqueue
+	url = https://github.com/cameron314/concurrentqueue

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ include_directories("${PROJECT_SOURCE_DIR}/src/runtime")
 include_directories("${PROJECT_SOURCE_DIR}/src/component")
 include_directories("${PROJECT_SOURCE_DIR}/src/wasm-rt")
 include_directories("${PROJECT_SOURCE_DIR}/src/storage")
-include_directories("${PROJECT_SOURCE_DIR}/third-party")
+include_directories(SYSTEM "${PROJECT_SOURCE_DIR}/third-party")
 
 add_subdirectory("${PROJECT_SOURCE_DIR}/src/util")
 add_subdirectory("${PROJECT_SOURCE_DIR}/src/http")

--- a/src/runtime/runtimestorage.cc
+++ b/src/runtime/runtimestorage.cc
@@ -65,7 +65,7 @@ void RuntimeStorage::schedule( Task task )
   }
   if ( remote == 0 ) {
     // schedule locally
-    current_worker().runq_.push( task );
+    current_worker().runq_.enqueue( task );
     work_++;
     work_.notify_all();
   } else {
@@ -78,7 +78,7 @@ bool RuntimeStorage::steal_work( Task& task, size_t tid )
 {
   // Starting at the next thread index after the current thread--look to steal work
   for ( size_t i = 0; i < num_workers_; ++i ) {
-    if ( workers_[( i + tid + 1 ) % num_workers_]->runq_.pop( task ) ) {
+    if ( workers_[( i + tid + 1 ) % num_workers_]->runq_.try_dequeue( task ) ) {
       return true;
     }
   }

--- a/src/runtime/worker.cc
+++ b/src/runtime/worker.cc
@@ -99,14 +99,14 @@ std::optional<Handle> RuntimeWorker::do_eval( Task task )
 
 void RuntimeWorker::queue_job( Task task )
 {
-  schedq_.push( task );
+  schedq_.enqueue( task );
 }
 
 optional<Task> RuntimeWorker::dequeue_job()
 {
   // Try to pop off the local queue, steal work if that fails, return false if no work can be found
   Task task;
-  bool work = runq_.pop( task );
+  bool work = runq_.try_dequeue( task );
 
   if ( !work ) {
     work = runtimestorage_.steal_work( task, thread_id_ );
@@ -253,9 +253,9 @@ void RuntimeWorker::work()
 
 void RuntimeWorker::schedule()
 {
-  while ( not schedq_.empty() ) {
+  while ( not( schedq_.size_approx() == 0 ) ) {
     Task task;
-    if ( not schedq_.pop( task ) ) {
+    if ( not schedq_.try_dequeue( task ) ) {
       break;
     }
     runtimestorage_.schedule( task );

--- a/src/runtime/worker.hh
+++ b/src/runtime/worker.hh
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <boost/lockfree/queue.hpp>
 #include <condition_variable>
 #include <queue>
 #include <thread>
 
+#include "concurrentqueue/concurrentqueue.h"
 #include "task.hh"
 
 #include "elfloader.hh"
@@ -18,10 +18,10 @@ private:
   friend class Job;
 
   /// A queue of runnable Tasks.
-  boost::lockfree::queue<Task> runq_;
+  moodycamel::ConcurrentQueue<Task> runq_;
 
   /// A queue of schedulable Tasks.
-  boost::lockfree::queue<Task> schedq_;
+  moodycamel::ConcurrentQueue<Task> schedq_;
 
   /// The thread corresponding to this Worker.
   std::thread thread_;


### PR DESCRIPTION
This PR replaces `boost::lockfree::queue` with another lock-free queue implementation with move semantics.