### PR TITLE
Send and receive evals of objects in repo

### DIFF
--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -55,7 +55,7 @@ class Remote : public ITaskRunner
   std::vector<EventLoop::RuleHandle> installed_rules_ {};
 
   size_t index_ {};
-  std::shared_ptr<MessageQueue> msg_q_ {};
+  MessageQueue& msg_q_;
 
   std::optional<ITaskRunner::Info> info_ {};
 
@@ -69,7 +69,7 @@ public:
           EventCategories categories,
           TCPSocket socket,
           size_t index,
-          std::shared_ptr<MessageQueue> msg_q,
+          MessageQueue& msg_q,
           IRuntime& runtime,
           absl::flat_hash_map<Task, size_t, absl::Hash<Task>>& reply_to,
           std::shared_mutex& mutex );
@@ -106,7 +106,7 @@ private:
   std::vector<Remote> connections_ {};
   std::vector<TCPSocket> server_sockets_ {};
 
-  std::shared_ptr<MessageQueue> msg_q_ { std::make_shared<MessageQueue>() };
+  MessageQueue msg_q_ {};
   IRuntime& runtime_;
 
   absl::flat_hash_map<Task, size_t, absl::Hash<Task>> reply_to_ {};
@@ -127,7 +127,6 @@ public:
 
   Address start_server( const Address& address )
   {
-    std::cout << "Start server." << std::endl;
     TCPSocket socket;
     socket.set_reuseaddr();
     socket.bind( address );
@@ -140,7 +139,6 @@ public:
 
   void connect( const Address& address )
   {
-    std::cout << "Connect." << std::endl;
     TCPSocket socket;
     socket.connect( address );
     connecting_sockets_ << std::move( socket );

--- a/src/runtime/runtime.hh
+++ b/src/runtime/runtime.hh
@@ -2,6 +2,7 @@
 
 #include "dependency_graph.hh"
 #include "interface.hh"
+#include "network.hh"
 #include "runtimestorage.hh"
 #include "scheduler.hh"
 #include "worker_pool.hh"
@@ -13,6 +14,7 @@ class Runtime : IRuntime
   WorkerPool workers_;
   Scheduler scheduler_;
   DependencyGraph graph_;
+  NetworkWorker network_;
 
   static inline thread_local Handle current_procedure_;
 
@@ -23,8 +25,9 @@ public:
     , workers_( 16, *this, graph_, storage_ )
     , scheduler_( workers_ )
     , graph_( cache_, scheduler_ )
+    , network_( *this )
   {
-    scheduler_.add_task_runner( workers_ );
+    graph_.add_result_cache( network_ );
   }
 
   static Runtime& get_instance()
@@ -46,4 +49,8 @@ public:
   Handle get_current_procedure() { return current_procedure_; }
 
   RuntimeStorage& storage() { return storage_; }
+
+  Address start_server( const Address& address ) { return network_.start_server( address ); }
+
+  void connect( const Address& address ) { network_.connect( address ); }
 };

--- a/src/runtime/worker_pool.hh
+++ b/src/runtime/worker_pool.hh
@@ -26,7 +26,12 @@ public:
     }
   }
 
-  std::optional<Handle> start( Task&& task )
+  std::optional<Info> get_info() override
+  {
+    return Info { .parallelism = static_cast<uint32_t>( std::thread::hardware_concurrency() ) };
+  }
+
+  std::optional<Handle> start( Task&& task ) override
   {
     runq_.push( std::move( task ) );
     return {};

--- a/src/tester/CMakeLists.txt
+++ b/src/tester/CMakeLists.txt
@@ -20,6 +20,14 @@ add_executable(network-tester "network-tester.cc" "tester-utils.cc")
 target_link_libraries(network-tester ${FIXPOINT_LIBS})
 target_link_libraries(network-tester wasmrt absl::flat_hash_map)
 
+add_executable(fixpoint-server "fixpoint-server.cc" "tester-utils.cc")
+target_link_libraries(fixpoint-server ${FIXPOINT_LIBS})
+target_link_libraries(fixpoint-server wasmrt absl::flat_hash_map)
+
+add_executable(fixpoint-client "fixpoint-client.cc" "tester-utils.cc")
+target_link_libraries(fixpoint-client ${FIXPOINT_LIBS})
+target_link_libraries(fixpoint-client wasmrt absl::flat_hash_map)
+
 # add_executable(distributed-tester "distributed-tester.cc" "tester-utils.cc")
 # target_link_libraries(distributed-tester ${FIXPOINT_LIBS})
 # target_link_libraries(distributed-tester cryptopp wasmrt absl::flat_hash_map)

--- a/src/tester/fixpoint-client.cc
+++ b/src/tester/fixpoint-client.cc
@@ -1,0 +1,83 @@
+#include <charconv>
+#include <cstdlib>
+#include <iostream>
+#include <unistd.h>
+
+#define RUNTIME_THREADS 1
+
+#include "tester-utils.hh"
+
+using namespace std;
+
+void program_body( span_view<char*> args )
+{
+  ios::sync_with_stdio( false );
+  vector<ReadOnlyFile> open_files;
+
+  args.remove_prefix( 1 ); // ignore argv[ 0 ]
+
+  auto& runtime = Runtime::get_instance();
+
+  while ( not args.empty() and args[0][0] == '+' ) {
+    string addr( &args[0][1] );
+    args.remove_prefix( 1 );
+    if ( addr.find( ':' ) == string::npos ) {
+      throw runtime_error( "invalid argument " + addr );
+    }
+    Address address( addr.substr( 0, addr.find( ':' ) ), stoi( addr.substr( addr.find( ':' ) + 1 ) ) );
+    cout << "Connecting to remote " << address.to_string() << "\n";
+    runtime.connect( address );
+  }
+
+  // make the combination from the given arguments
+  Handle encode_name = parse_args( args, open_files );
+
+  if ( not args.empty() ) {
+    throw runtime_error( "unexpected argument: "s + args.at( 0 ) );
+  }
+
+  // add the combination to the store, and print it
+  cout << "Combination:\n" << pretty_print( encode_name ) << endl;
+
+  // make a Thunk that points to the combination
+  Handle thunk_name = runtime.storage().add_thunk( Thunk { encode_name } );
+
+  // Wait for the handshake
+  sleep( 1 );
+
+  // force the Thunk and print it
+  Handle result = runtime.eval( thunk_name );
+
+  // print the result
+  cout << "Result:\n" << pretty_print( result );
+}
+
+void usage_message( const char* argv0 )
+{
+  cerr << "Usage: " << argv0 << " [+server:port]... entry...\n";
+  cerr << "   entry :=   file:<filename>\n";
+  cerr << "            | string:<string>\n";
+  cerr << "            | name:<base64-encoded name>\n";
+  cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
+  cerr << "            | tree:<n> (followed by <n> entries)\n";
+  cerr << "            | thunk: (followed by tree:<n>)\n";
+  cerr << "            | compile:<filename>\n";
+  cerr << "            | ref:<ref>\n";
+}
+
+int main( int argc, char* argv[] )
+{
+  if ( argc <= 0 ) {
+    abort();
+  }
+
+  if ( argc < 2 ) {
+    usage_message( argv[0] );
+    return EXIT_FAILURE;
+  }
+
+  span_view<char*> args = { argv, static_cast<size_t>( argc ) };
+  program_body( args );
+
+  return EXIT_SUCCESS;
+}

--- a/src/tester/fixpoint-server.cc
+++ b/src/tester/fixpoint-server.cc
@@ -1,0 +1,51 @@
+#include <iostream>
+
+#include "runtime.hh"
+#include "tester-utils.hh"
+
+using namespace std;
+
+void program_body( span_view<char*> args )
+{
+  ios::sync_with_stdio( false );
+  vector<ReadOnlyFile> open_files;
+
+  args.remove_prefix( 1 ); // ignore argv[ 0 ]
+
+  uint16_t port = 0;
+  if ( not args.empty() ) {
+    port = stoi( args[0] );
+    args.remove_prefix( 1 );
+  }
+
+  Address address( "0.0.0.0", port );
+
+  auto& rt = Runtime::get_instance();
+  rt.storage().deserialize();
+  Address listen_address = rt.start_server( address );
+  cout << "Listening on " << listen_address.to_string() << endl;
+  while ( true )
+    ;
+}
+
+void usage_message( const char* argv0 )
+{
+  cerr << "Usage: " << argv0 << " [port]\n";
+}
+
+int main( int argc, char* argv[] )
+{
+  if ( argc <= 0 ) {
+    abort();
+  }
+
+  if ( argc > 2 ) {
+    usage_message( argv[0] );
+    return EXIT_FAILURE;
+  }
+
+  span_view<char*> args = { argv, static_cast<size_t>( argc ) };
+  program_body( args );
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
`fixpoint-client` can start a computation and send it to `fixpoint-server` for completion. The scheduler now always sends tasks to the job with the highest amount of "parallelism" (not true parallelism, since we're always using 16 threads but still report that we're using one core per CPU to the scheduler).  Since we do no data transfer and only send Handles around (without even canonicalizing them), this basically only works for evaluating things which already exist on disk as part of the repo right now (e.g., `eval(compile-encode)` works).

Related to #66, requires #106 for more progress.