### PR TITLE
Expose "Minimum Repository" via RuntimeStorage

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,220 @@
+# Fixpoint API: Fix's interface in Wasm
+
+The Wasm module must export a function named `_fixpoint_apply` of type
+`externref -> externref`. Fix uses the `externref` type to represent a Handle.
+The function will be called with the Name of the Encode. The Object named in the
+function's return value will be the result of `apply`.
+
+To give the Wasm module access to the Encode and the ability to create new
+Objects, Fix makes available the following host functions as imports. Each of
+them can be imported from the \"`fix`\" namespace. 
+
+Note: the API uses `externref`'s to represent Handles for Objects. Some Handles 
+below have more specific accessibilities and specific Objects. We refer here to 
+strict Handles with `&`, shallow Handles with `&shallow`, and lazy Handles with 
+`&lazy`. Handles with irrelevant accessibility will be described with `&any`.
+We refer to Objects as `Object` in the general case and `Tree`, `Thunk`, 
+`Blob`, or `Tag` in the other cases. Thus, when we write `&Tree`, we mean a 
+strict handle to a Tree, represented as an `externref` to the Wasm API, or when 
+we write `&lazy Object`, we mean a lazy handle to some Object. 
+
+## attach_tree_ro_table
+
+```rust
+fn attach_tree_ro_table_N(handle: &Tree) -> ();
+fn attach_tree_ro_table_N(handle: &Tag) -> ();
+```
+"attaches" the Tree or Tag to the Wasm table numbered *N*. Future calls to `table.get`, 
+`table.size` or `table.copy` (referring to table *N* as a source) will refer to 
+the entries of this Tree or Tag.
+
+The table must:
+- Be exported under the name `ro_table_N`,
+- Not be exported under another name,
+- Never be the target of an instruction that would mutate it (`table.set`, 
+`table.init`, `table.fill`, `table.copy`, `table.grow`).
+These table properties are checked statically upfront by wasminspector.
+
+## attach_blob_ro_mem
+
+```rust
+fn attach_blob_ro_mem_N(handle: &Blob) -> ();
+```
+“attaches” the Blob to the Wasm memory numbered *N*. Future calls to `*.load` 
+instructions as well as `memory.size` or `memory.copy` (referring to memory 
+*N* as a source) will refer to the bytes of this Blob. 
+
+The memory must:
+- Be exported under the name `ro_mem_N`,
+- Not be exported under another name,
+- Never be the target of an instruction that would mutate it (`*.store`,
+  `memory.init`, `memory.fill`, `memory.copy`, `memory.grow`).
+  These memory properties are checked statically upfront by wasminspector.
+
+## size_ro_mem
+
+```rust
+fn size_ro_mem_N() -> i32;
+```
+Returns the size of the Blob attached to memory *N*, in bytes (or zero if no 
+blob is attached to this memory). This differs from the `memory.size` 
+instruction, which must return an integer number of 64 KiB pages. The read-only 
+memory must meet the same statically checked requirements as above.
+
+## create_blob_rw_mem
+
+```rust
+fn create_blob_rw_mem_N(length_in_bytes: i32) -> &Blob;
+```
+“Detaches” the contents of memory *N* and creates a Blob with length
+in bytes as given in the i32 argument. This length must be less than or equal 
+to the data length of memory *N*. Returns a strict Handle referencing the newly 
+created Blob. The memory must be exported under the name `rw_mem_N`.
+
+## create_blob
+
+```rust
+fn create_blob_i32(value: i32) -> &Blob;
+```
+Same as `create_blob_rw_mem_N`, but creates the Blob from an argument given on the stack instead
+of from a read-write memory. 
+
+The possible immediate types may be expanded in the future from i32 to be any 
+of the numeric or vector types of Wasm: i32, i64, f32, f64, or v128.
+
+## create_tree_rw_table
+
+```rust
+fn create_tree_rw_table_N(length_in_entries: i32) -> &Tree;
+```
+"Detaches” the contents of table *N* and creates a Tree whose length in entries
+is given by the i32 argument. This length must be less than or equal to the 
+length of table *N*. Returns a strict Handle referencing the newly created Tree. 
+The table must be exported under the name `rw_table_N`.
+
+## create_thunk
+
+```rust
+fn create_thunk(handle: &Tree) -> &Thunk;
+```
+Given a Tree, creates a corresponding Thunk as a strict Handle. The Tree should
+be in Encode format, but this property is not checked by fixpoint. 
+
+## create_tag
+
+```rust
+fn create_tag(target: &any Object, tag_data: &Blob) -> &Tag;
+```
+Given the `target` object to be tagged and the custom `tag_data`, returns the
+Handle of a Tag `{x, current_procedure, y}`. Used to unforgeably mark Objects.
+
+Currently, `tag_data` is not being checked to be a `Blob` and the strict
+requirement is not known to be necessary.
+
+## get_value_type
+
+```rust
+fn get_value_type(handle: &any Object) -> i32;
+```
+Retrieve type (Tree = 0, Thunk = 1, Blob = 2 or Tag = 3) from a Handle. 
+
+## get_length
+
+```rust
+fn get_length(handle: &Object) -> i32;
+fn get_length(handle: &shallow Object) -> i32;
+```
+Given an strict or shallow Handle, returns the length (in bytes or number of 
+entries) of the corresponding Value.
+
+## get_access
+
+```rust
+fn get_access(handle: &any Object) -> i32;
+```
+Retrieve accessibility type (Strict = 0, Shallow = 1, Lazy = 2) from a Handle.
+
+## shallow_get
+
+```rust
+fn shallow_get(handle: &shallow Tree, index: i32) -> &lazy Object;
+```
+Given a shallow Handle that refers to a Tree, returns a lazy Handle that refers
+to the same Object as the Handle in the specified entry of the Tree.
+
+## lift
+
+```rust
+fn lift(handle: &any Object) -> &strict Thunk;
+```
+Given a Handle, returns a Thunk that applies *fetch* to the Handle as a strict 
+Handle.
+
+Not yet implemented. 
+
+## lower
+
+```rust
+fn lower(handle: &strict Object) -> &shallow Object;
+fn lower(handle: &shallow Object) -> &lazy Object;
+fn lower(handle: &lazy Object) -> &lazy Object;
+```
+Given a Handle, if the Handle is strict, returns the shallow Handle that points
+to the same Object. If the Handle is shallow, returns the lazy Handle that 
+points to the same Object. If the Handle is lazy, returns the same Handle.
+
+Not yet implemented. 
+
+## get_name
+
+```rust
+fn get_name(handle: &strict Object) -> (i64, i64, i64, i64);
+```
+
+Given a strict or shallow Blob Handle, return the canonical name of the Blob in 
+the form of `(i64, i64, i64, i64)`. 
+
+Not yet implemented. 
+
+# Debugging Functions
+
+A few additional API functions are provided for use from non-deterministic
+contexts, e.g., a debug-mode thunk.  These functions query state outside of
+Fix, such as whether a particular computation has already happened, but cannot
+modify any state.  While it is possible to call them in deterministic contexts,
+the result will always be a deterministic trap.
+
+These functions are all partially implemented; they currently don't trap from
+deterministic contexts.
+
+
+## debug_try_lift
+
+```rust
+fn debug_try_lift(handle: &any Object) -> &any Object;
+```
+
+Given a Handle, attempts to return the strictest possible Handle the system can
+validly construct for the same object.  The accessibility of the returned
+Handle is guaranteed to be *at least* as strict as the input Handle.
+
+## debug_try_inspect
+
+```rust
+fn debug_try_inspect(handle: &any Thunk) -> Result<&lazy Tree, &any Thunk>;
+```
+
+Given a Handle to a Thunk, attempt to return a handle to its encode.  It may
+not always be possible to recover the encode from a Thunk (e.g., if the encode
+was garbage collected), so this operation may fail by returning the original
+Thunk.
+
+## debug_try_evaluate
+
+```rust
+fn debug_try_evaluate(handle: &any Object) -> Result<&lazy Object, &any Object>;
+```
+
+Given a Handle, attempt to evaluate it.  This will query Fixcache, returning a
+lazy Handle to the evaluated result if it's found or the original Handle if
+it's not found.

--- a/docs/design.md
+++ b/docs/design.md
@@ -129,222 +129,33 @@ Encode format, `apply(`*x*`)` is defined as:
   * If *x* is lazy, returns a shallow Handle that refers to the same Object
     that *x* refers to. Otherwise, return *x*.
 
-# Fix's interface to Wasm
-The Wasm module must export a function named `_fixpoint_apply` of type
-`externref -> externref`. Fix uses the `externref` type to represent a Handle.
-The function will be called with the Name of the Encode. The Object named in the
-function's return value will be the result of `apply`.
+# Minimum Repository
 
-To give the Wasm module access to the Encode and the ability to create new
-Objects, Fix makes available the following host functions as imports. Each of
-them can be imported from the \"`fix`\" namespace. 
+For any given evaluation, there's a minimum set of information which must be
+present in a Fix repo to perform it.  We call this the "minimum repository", or
+"minrepo", of the Handle to be evaluated.
 
-Note: the API uses `externref`'s to represent Handles for Objects. Some Handles 
-below have more specific accessibilities and specific Objects. We refer here to 
-strict Handles with `&`, shallow Handles with `&shallow`, and lazy Handles with 
-`&lazy`. Handles with irrelevant accessibility will be described with `&any`.
-We refer to Objects as `Object` in the general case and `Tree`, `Thunk`, 
-`Blob`, or `Tag` in the other cases. Thus, when we write `&Tree`, we mean a 
-strict handle to a Tree, represented as an `externref` to the Wasm API, or when 
-we write `&lazy Object`, we mean a lazy handle to some Object. 
+The minimum repository is defined recursively:
 
-## attach_tree_ro_table
+1. The minrepo of a lazy Handle is that lazy Handle.
+2. The minrepo of a Blob is its Handle and contents.
+3. The minrepo of a Strict Tree/Tag is the union of the minrepos of every
+   child, as well as the Handle and contents of the Tree/Tag itself.
+4. The minrepo of a Shallow Tree/Tag is the Handle and contents of the
+   Tree/Tag.
+5. The minrepo of a Thunk is the union of the minrepo of the ENCODE Tree and
+   the Thunk's Handle.
 
-```rust
-fn attach_tree_ro_table_N(handle: &Tree) -> ();
-fn attach_tree_ro_table_N(handle: &Tag) -> ();
-```
-"attaches" the Tree or Tag to the Wasm table numbered *N*. Future calls to `table.get`, 
-`table.size` or `table.copy` (referring to table *N* as a source) will refer to 
-the entries of this Tree or Tag.
+However, we can elide all Handles except the root from the minimum repository,
+since every child must be reachable from the root; the Handles are therefore
+contained within Trees or Tags already.  This reduces the minrepo to the
+contents of Blobs, Tags, and Trees which are reachable using the above rules.
+The most notable changes are:
+1. Lazy Handles can be completely ignored, since they carry no data.
+2. Thunk Handles can be skipped, since all their data are carried on the
+   ENCODE.
 
-The table must:
-- Be exported under the name `ro_table_N`,
-- Not be exported under another name,
-- Never be the target of an instruction that would mutate it (`table.set`, 
-`table.init`, `table.fill`, `table.copy`, `table.grow`).
-These table properties are checked statically upfront by wasminspector.
-
-## attach_blob_ro_mem
-
-```rust
-fn attach_blob_ro_mem_N(handle: &Blob) -> ();
-```
-“attaches” the Blob to the Wasm memory numbered *N*. Future calls to `*.load` 
-instructions as well as `memory.size` or `memory.copy` (referring to memory 
-*N* as a source) will refer to the bytes of this Blob. 
-
-The memory must:
-- Be exported under the name `ro_mem_N`,
-- Not be exported under another name,
-- Never be the target of an instruction that would mutate it (`*.store`,
-  `memory.init`, `memory.fill`, `memory.copy`, `memory.grow`).
-  These memory properties are checked statically upfront by wasminspector.
-
-## size_ro_mem
-
-```rust
-fn size_ro_mem_N() -> i32;
-```
-Returns the size of the Blob attached to memory *N*, in bytes (or zero if no 
-blob is attached to this memory). This differs from the `memory.size` 
-instruction, which must return an integer number of 64 KiB pages. The read-only 
-memory must meet the same statically checked requirements as above.
-
-## create_blob_rw_mem
-
-```rust
-fn create_blob_rw_mem_N(length_in_bytes: i32) -> &Blob;
-```
-“Detaches” the contents of memory *N* and creates a Blob with length
-in bytes as given in the i32 argument. This length must be less than or equal 
-to the data length of memory *N*. Returns a strict Handle referencing the newly 
-created Blob. The memory must be exported under the name `rw_mem_N`.
-
-## create_blob
-
-```rust
-fn create_blob_i32(value: i32) -> &Blob;
-```
-Same as `create_blob_rw_mem_N`, but creates the Blob from an argument given on the stack instead
-of from a read-write memory. 
-
-The possible immediate types may be expanded in the future from i32 to be any 
-of the numeric or vector types of Wasm: i32, i64, f32, f64, or v128.
-
-## create_tree_rw_table
-
-```rust
-fn create_tree_rw_table_N(length_in_entries: i32) -> &Tree;
-```
-"Detaches” the contents of table *N* and creates a Tree whose length in entries
-is given by the i32 argument. This length must be less than or equal to the 
-length of table *N*. Returns a strict Handle referencing the newly created Tree. 
-The table must be exported under the name `rw_table_N`.
-
-## create_thunk
-
-```rust
-fn create_thunk(handle: &Tree) -> &Thunk;
-```
-Given a Tree, creates a corresponding Thunk as a strict Handle. The Tree should
-be in Encode format, but this property is not checked by fixpoint. 
-
-## create_tag
-
-```rust
-fn create_tag(target: &any Object, tag_data: &Blob) -> &Tag;
-```
-Given the `target` object to be tagged and the custom `tag_data`, returns the
-Handle of a Tag `{x, current_procedure, y}`. Used to unforgeably mark Objects.
-
-Currently, `tag_data` is not being checked to be a `Blob` and the strict
-requirement is not known to be necessary.
-
-## get_value_type
-
-```rust
-fn get_value_type(handle: &any Object) -> i32;
-```
-Retrieve type (Tree = 0, Thunk = 1, Blob = 2 or Tag = 3) from a Handle. 
-
-## get_length
-
-```rust
-fn get_length(handle: &Object) -> i32;
-fn get_length(handle: &shallow Object) -> i32;
-```
-Given an strict or shallow Handle, returns the length (in bytes or number of 
-entries) of the corresponding Value.
-
-## get_access
-
-```rust
-fn get_access(handle: &any Object) -> i32;
-```
-Retrieve accessibility type (Strict = 0, Shallow = 1, Lazy = 2) from a Handle.
-
-## shallow_get
-
-```rust
-fn shallow_get(handle: &shallow Tree, index: i32) -> &lazy Object;
-```
-Given a shallow Handle that refers to a Tree, returns a lazy Handle that refers
-to the same Object as the Handle in the specified entry of the Tree.
-
-## lift
-
-```rust
-fn lift(handle: &any Object) -> &strict Thunk;
-```
-Given a Handle, returns a Thunk that applies *fetch* to the Handle as a strict 
-Handle.
-
-Not yet implemented. 
-
-## lower
-
-```rust
-fn lower(handle: &strict Object) -> &shallow Object;
-fn lower(handle: &shallow Object) -> &lazy Object;
-fn lower(handle: &lazy Object) -> &lazy Object;
-```
-Given a Handle, if the Handle is strict, returns the shallow Handle that points
-to the same Object. If the Handle is shallow, returns the lazy Handle that 
-points to the same Object. If the Handle is lazy, returns the same Handle.
-
-Not yet implemented. 
-
-## get_name
-
-```rust
-fn get_name(handle: &strict Object) -> (i64, i64, i64, i64);
-```
-
-Given a strict or shallow Blob Handle, return the canonical name of the Blob in 
-the form of `(i64, i64, i64, i64)`. 
-
-Not yet implemented. 
-
-# Debugging Functions
-
-A few additional API functions are provided for use from non-deterministic
-contexts, e.g., a debug-mode thunk.  These functions query state outside of
-Fix, such as whether a particular computation has already happened, but cannot
-modify any state.  While it is possible to call them in deterministic contexts,
-the result will always be a deterministic trap.
-
-These functions are all partially implemented; they currently don't trap from
-deterministic contexts.
-
-
-## debug_try_lift
-
-```rust
-fn debug_try_lift(handle: &any Object) -> &any Object;
-```
-
-Given a Handle, attempts to return the strictest possible Handle the system can
-validly construct for the same object.  The accessibility of the returned
-Handle is guaranteed to be *at least* as strict as the input Handle.
-
-## debug_try_inspect
-
-```rust
-fn debug_try_inspect(handle: &any Thunk) -> Result<&lazy Tree, &any Thunk>;
-```
-
-Given a Handle to a Thunk, attempt to return a handle to its encode.  It may
-not always be possible to recover the encode from a Thunk (e.g., if the encode
-was garbage collected), so this operation may fail by returning the original
-Thunk.
-
-## debug_try_evaluate
-
-```rust
-fn debug_try_evaluate(handle: &any Object) -> Result<&lazy Object, &any Object>;
-```
-
-Given a Handle, attempt to evaluate it.  This will query Fixcache, returning a
-lazy Handle to the evaluated result if it's found or the original Handle if
-it's not found.
+When Fixpoint sends a value to another node, it must ensure the minrepo is
+available on the remote node.  A Fixpoint Handle for which the minrepo is not
+present is not a valid Fix Handle, since attaching it is unsafe and may cause a
+panic.

--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -13,3 +13,5 @@ add_test(NAME t_add_flatware WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DI
 add_test(NAME t_open_flatware WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-open-flatware)
 add_test(NAME t_return_flatware WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-return-flatware)
 add_test(NAME t_helloworld_flatware WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-helloworld-flatware)
+
+add_test(NAME t_storage WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-storage)

--- a/src/component/handle.hh
+++ b/src/component/handle.hh
@@ -145,7 +145,7 @@ public:
     }
   }
 
-  bool is_canonical() const { return !is_literal_blob() && metadata() & 0x04; }
+  bool is_canonical() const { return is_literal_blob() or metadata() & 0x04; }
 
   bool is_local() const { return !is_literal_blob() && !is_canonical(); }
 
@@ -245,10 +245,22 @@ public:
     return _mm256_or_si256( bits, masked );
   }
 
-  Handle get_encode_name() { return Handle::get_encode_name( *this ); }
-  Handle as_strict() { return Handle::make_strict( *this ); }
-  Handle as_shallow() { return Handle::make_shallow( *this ); }
-  Handle as_lazy() { return Handle::make_lazy( *this ); }
+  Handle get_encode_name() const { return Handle::get_encode_name( *this ); }
+  Handle as_strict() const { return Handle::make_strict( *this ); }
+  Handle as_shallow() const { return Handle::make_shallow( *this ); }
+  Handle as_lazy() const { return Handle::make_lazy( *this ); }
+  Handle with_laziness( Laziness laziness ) const
+  {
+    switch ( laziness ) {
+      case Laziness::Lazy:
+        return as_lazy();
+      case Laziness::Shallow:
+        return as_shallow();
+      case Laziness::Strict:
+        return as_strict();
+    }
+    __builtin_unreachable();
+  }
 
   friend bool operator==( Handle lhs, Handle rhs );
   friend std::ostream& operator<<( std::ostream& s, const Handle name );

--- a/src/runtime/fixpointapi.cc
+++ b/src/runtime/fixpointapi.cc
@@ -130,10 +130,9 @@ uint32_t get_value_type( __m256i handle )
 uint32_t equality( __m256i lhs, __m256i rhs )
 {
   TRACE_2( lhs, rhs );
-  // XXX: proper equality
   Handle left( lhs );
   Handle right( rhs );
-  return ( left == right );
+  return Runtime::get_instance().storage().compare_handles( left, right );
 }
 
 void unsafe_io( int32_t index, int32_t length, wasm_rt_memory_t* mem )

--- a/src/runtime/runtimestorage.hh
+++ b/src/runtime/runtimestorage.hh
@@ -72,7 +72,7 @@ public:
 
   void add_program( Handle function_name, std::string_view elf_content );
 
-  Handle local_to_storage( Handle name );
+  Handle canonicalize( Handle name );
 
   std::string serialize( Handle handle );
   void deserialize();
@@ -104,4 +104,27 @@ public:
 
   // Adds a ref for a Handle in-memory (but does not serialize the ref to disk)
   void set_ref( std::string_view ref, Handle handle );
+
+  /**
+   * Call @p visitor for every Handle in the "minimum repo" of @p root, i.e., the set of Handles needed for @p root
+   * to be valid as input to a Fix program.
+   *
+   * The iteration order is such that every child will be visited before its parents.
+   *
+   * @param root            The Handle from which to start traversing inputs.
+   * @param visitor         A function to call on every dependency.
+   * @param include_lazy    Whether or not to visit Lazy Handles, which have no data in their minrepo.
+   * @param include_thunks  Whether or not to visit Thunks, which have no data besides their Tree.
+   */
+  void visit( Handle root,
+              std::function<void( Handle )> visitor,
+              bool include_lazy = true,
+              bool include_thunks = true );
+
+  /**
+   * Determines if two Handles should be treated as equal.  This might canonicalize the Handles if necessary.
+   *
+   * @return  true if the Handles refer to the same object, false otherwise
+   */
+  bool compare_handles( Handle x, Handle y );
 };

--- a/src/runtime/worker.cc
+++ b/src/runtime/worker.cc
@@ -127,7 +127,7 @@ Handle RuntimeWorker::do_apply( Task task )
   }
 
   Handle function_name = tag.at( 0 );
-  Handle canonical_name = storage_.local_to_storage( function_name );
+  Handle canonical_name = storage_.canonicalize( function_name );
   if ( not storage_.name_to_program_.contains( canonical_name ) ) {
     /* Link program */
     Program program = link_program( storage_.get_blob( function_name ) );

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -29,3 +29,7 @@ target_link_libraries(test-helloworld-flatware cryptopp wasmrt absl::flat_hash_m
 add_executable(test-map test-map.cc)
 target_link_libraries(test-map ${FIXPOINT_LIBS})
 target_link_libraries(test-map cryptopp wasmrt absl::flat_hash_map)
+
+add_executable(test-storage test-storage.cc)
+target_link_libraries(test-storage ${FIXPOINT_LIBS})
+target_link_libraries(test-storage cryptopp wasmrt absl::flat_hash_map)

--- a/src/tests/test-storage.cc
+++ b/src/tests/test-storage.cc
@@ -1,0 +1,72 @@
+#include <stdio.h>
+
+#include "test.hh"
+
+using namespace std;
+
+#define CHECK( condition )                                                                                         \
+  if ( not( condition ) ) {                                                                                        \
+    fprintf( stderr, "%s:%d - assertion '%s' failed\n", __FILE__, __LINE__, #condition );                          \
+    exit( 1 );                                                                                                     \
+  }
+
+int main( int, char** )
+{
+  auto& rt = Runtime::get_instance();
+  auto& s = rt.storage();
+
+  Handle data = tree( {
+    blob( "visible 1" ),
+    blob( "visible 2" ),
+    tree( { blob( "not visible" ) } ).as_lazy(),
+    blob( "visible 3" ),
+    thunk( tree( {
+             blob( "unused" ),
+             blob( "elf" ),
+           } ) )
+      .as_lazy(),
+  } );
+
+  size_t count = 0;
+  s.visit(
+    data,
+    [&]( Handle h ) {
+      count++;
+      CHECK( not s.compare_handles( h, blob( "not visible" ) ) );
+      CHECK( not s.compare_handles( h, blob( "unused" ) ) );
+      CHECK( not s.compare_handles( h, blob( "elf" ) ) );
+    },
+    true,
+    true );
+  CHECK( count == 6 );
+
+  count = 0;
+  s.visit(
+    data,
+    [&]( Handle h ) {
+      count++;
+      CHECK( not s.compare_handles( h, blob( "not visible" ) ) );
+      CHECK( not s.compare_handles( h, blob( "unused" ) ) );
+      CHECK( not s.compare_handles( h, blob( "elf" ) ) );
+      CHECK( not s.compare_handles( h, tree( { blob( "not visible" ) } ).as_lazy() ) );
+      CHECK( not h.is_lazy() );
+      CHECK( not h.is_thunk() );
+    },
+    false,
+    true );
+  CHECK( count == 4 );
+
+  count = 0;
+  s.visit(
+    data,
+    [&]( Handle h ) {
+      count++;
+      CHECK( not s.compare_handles( h, blob( "not visible" ) ) );
+      CHECK( not s.compare_handles( h, blob( "unused" ) ) );
+      CHECK( not s.compare_handles( h, blob( "elf" ) ) );
+      CHECK( not h.is_thunk() );
+    },
+    true,
+    false );
+  CHECK( count == 5 );
+}


### PR DESCRIPTION
Defines a "minimum repository"—the smallest set of Handles needed to evaluate another Handle—and provides `RuntimeStorage::visit` to iterate over it.  The function allows the caller to select whether or not Lazy Handles are included; they are inherently leaf nodes with no associated data, so there may not be a point in including them in a traversal.  The same also applies to Thunks, since they can be trivially inferred from the ENCODE Tree.

Shallowness is only considered for Trees and Tags, since shallow Blobs are not yet well-defined.  Shallow Blobs are treated as strict.

Resolves #47, since we needed a canonicalizing equality function for the test cases here anyway.  Also fixes a bug that canonicalizing would always promote a Handle to strict (the function was previously defined on Names, not on Handles).

Needed for #106.