### PR TITLE
Add message handling for sending objects

### DIFF
--- a/src/component/handle.hh
+++ b/src/component/handle.hh
@@ -147,7 +147,7 @@ public:
 
   bool is_canonical() const { return is_literal_blob() or metadata() & 0x04; }
 
-  bool is_local() const { return !is_literal_blob() && !is_canonical(); }
+  bool is_local() const { return !is_canonical(); }
 
   bool is_blob() const
   {

--- a/src/runtime/message.cc
+++ b/src/runtime/message.cc
@@ -2,32 +2,30 @@
 #include "base64.hh"
 #include "object.hh"
 #include "parser.hh"
+#include <optional>
 
 using namespace std;
 
-Message::Message( string_view header, string&& payload )
-  : opcode_( Message::opcode( header ) )
-  , payload_( move( payload ) )
+IncomingMessage::IncomingMessage( string_view header, string&& payload )
+  : Message( Message::opcode( header ), move( payload ) )
 {}
 
-Message::Message( string_view header, Blob&& payload )
-  : opcode_( Message::opcode( header ) )
-  , payload_( move( payload ) )
+IncomingMessage::IncomingMessage( string_view header, Blob&& payload )
+  : Message( Message::opcode( header ), move( payload ) )
 {}
 
-Message::Message( string_view header, Tree&& payload )
-  : opcode_( Message::opcode( header ) )
-  , payload_( move( payload ) )
+IncomingMessage::IncomingMessage( string_view header, Tree&& payload )
+  : Message( Message::opcode( header ), move( payload ) )
 {}
 
-Message::Message( const Opcode opcode, string&& payload )
-  : opcode_( opcode )
-  , payload_( move( payload ) )
+OutgoingMessage::OutgoingMessage( const Opcode opcode, string&& payload, optional<Handle> dependency )
+  : Message( opcode, move( payload ) )
+  , data_dependnecy_( dependency )
 {}
 
-Message::Message( const Opcode opcode, string_view payload )
-  : opcode_( opcode )
-  , payload_( payload )
+OutgoingMessage::OutgoingMessage( const Opcode opcode, string_view payload, optional<Handle> dependency )
+  : Message( opcode, payload )
+  , data_dependnecy_( dependency )
 {}
 
 void Message::serialize_header( string& out )

--- a/src/runtime/message.hh
+++ b/src/runtime/message.hh
@@ -89,6 +89,7 @@ private:
 public:
   OutgoingMessage() {};
   OutgoingMessage( const Opcode opcode, std::string&& payload, std::optional<Handle> dependency = {} );
+  // Construct an non_owning data, backing data have to outlive the message
   OutgoingMessage( const Opcode opcode, std::string_view payload, std::optional<Handle> dependency = {} );
 
   std::optional<Handle> get_dependency() { return data_dependnecy_; }

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -184,7 +184,7 @@ void Remote::process_incoming_message( Message&& msg )
     }
 
     case Opcode::REQUESTINFO: {
-      InfoPayload payload { { .parallelism = thread::hardware_concurrency() } };
+      InfoPayload payload { runtime_.get_info().value_or( ITaskRunner::Info { .parallelism = 0 } ) };
       push_message( { Opcode::INFO, serialize( payload ) } );
       break;
     }

--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -21,7 +21,7 @@
 
 using ResultChannel = Channel<std::pair<Task, Handle>>;
 using WorkChannel = Channel<Task>;
-using MessageQueue = moodycamel::ConcurrentQueue<std::pair<uint32_t, Message>>;
+using MessageQueue = moodycamel::ConcurrentQueue<std::pair<uint32_t, OutgoingMessage>>;
 
 struct EventCategories
 {
@@ -48,7 +48,7 @@ class Remote : public ITaskRunner
   RingBuffer tx_data_ { 8192 };
 
   MessageParser rx_messages_ {};
-  std::queue<Message> tx_messages_ {};
+  std::queue<OutgoingMessage> tx_messages_ {};
 
   std::string current_msg_header_ {};
   std::string_view current_msg_unsent_header_ {};
@@ -79,7 +79,7 @@ public:
   std::optional<Handle> start( Task&& task ) override;
   std::optional<ITaskRunner::Info> get_info() override { return info_; }
 
-  void push_message( Message&& msg );
+  void push_message( OutgoingMessage&& msg );
 
   bool is_connected();
   Address local_address() { return socket_.local_address(); }
@@ -92,7 +92,7 @@ private:
   void write_to_rb();
   void read_from_rb();
   void install_rule( EventLoop::RuleHandle rule ) { installed_rules_.push_back( rule ); }
-  void process_incoming_message( Message&& msg );
+  void process_incoming_message( IncomingMessage&& msg );
 
   void send_blob( std::string_view blob );
   void send_tree( span_view<Handle> tree );

--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -36,6 +36,8 @@ struct EventCategories
   size_t forward_msg;
 };
 
+class Runtime;
+
 class Remote : public ITaskRunner
 {
   EventLoop& events_;
@@ -62,7 +64,7 @@ class Remote : public ITaskRunner
   absl::flat_hash_map<Task, size_t, absl::Hash<Task>>& reply_to_;
   std::shared_mutex& mutex_;
 
-  IRuntime& runtime_;
+  Runtime& runtime_;
 
 public:
   Remote( EventLoop& events,
@@ -70,7 +72,7 @@ public:
           TCPSocket socket,
           size_t index,
           MessageQueue& msg_q,
-          IRuntime& runtime,
+          Runtime& runtime,
           absl::flat_hash_map<Task, size_t, absl::Hash<Task>>& reply_to,
           std::shared_mutex& mutex );
 
@@ -83,12 +85,18 @@ public:
   Address local_address() { return socket_.local_address(); }
   Address peer_address() { return socket_.peer_address(); }
 
+  void send_object( Handle handle );
+
 private:
   void load_tx_message();
   void write_to_rb();
   void read_from_rb();
   void install_rule( EventLoop::RuleHandle rule ) { installed_rules_.push_back( rule ); }
   void process_incoming_message( Message&& msg );
+
+  void send_blob( std::string_view blob );
+  void send_tree( span_view<Handle> tree );
+  void send_tag( span_view<Handle> tag );
 };
 
 class NetworkWorker : public IResultCache
@@ -107,7 +115,7 @@ private:
   std::vector<TCPSocket> server_sockets_ {};
 
   MessageQueue msg_q_ {};
-  IRuntime& runtime_;
+  Runtime& runtime_;
 
   absl::flat_hash_map<Task, size_t, absl::Hash<Task>> reply_to_ {};
   std::shared_mutex mutex_ {};
@@ -115,7 +123,7 @@ private:
   void run_loop();
 
 public:
-  NetworkWorker( IRuntime& runtime )
+  NetworkWorker( Runtime& runtime )
     : network_thread_( std::bind( &NetworkWorker::run_loop, this ) )
     , runtime_( runtime ) {};
 

--- a/src/runtime/runtime.hh
+++ b/src/runtime/runtime.hh
@@ -41,7 +41,16 @@ public:
   }
 
   std::optional<Handle> start( Task&& task ) override { return graph_.start( std::move( task ) ); }
-  void finish( Task&& task, Handle result ) override { graph_.finish( std::move( task ), result ); }
+  void finish( Task&& task, Handle result ) override
+  {
+    auto local_handle = storage_.get_local_name( task.handle() );
+    if ( local_handle.has_value() ) {
+      Task local_task( local_handle.value(), task.operation() );
+      graph_.finish( std::move( local_task ), result );
+    }
+
+    graph_.finish( std::move( task ), result );
+  }
 
   std::optional<Info> get_info() override { return workers_.get_info(); }
 

--- a/src/runtime/runtime.hh
+++ b/src/runtime/runtime.hh
@@ -7,6 +7,10 @@
 #include "scheduler.hh"
 #include "worker_pool.hh"
 
+#ifndef RUNTIME_THREADS
+#define RUNTIME_THREADS std::thread::hardware_concurrency()
+#endif
+
 class Runtime : IRuntime
 {
   FixCache cache_;
@@ -22,7 +26,7 @@ public:
   Runtime()
     : cache_()
     , storage_()
-    , workers_( std::thread::hardware_concurrency(), *this, graph_, storage_ )
+    , workers_( RUNTIME_THREADS, *this, graph_, storage_ )
     , scheduler_( workers_ )
     , graph_( cache_, scheduler_ )
     , network_( *this )
@@ -38,6 +42,8 @@ public:
 
   std::optional<Handle> start( Task&& task ) override { return graph_.start( std::move( task ) ); }
   void finish( Task&& task, Handle result ) override { graph_.finish( std::move( task ), result ); }
+
+  std::optional<Info> get_info() override { return workers_.get_info(); }
 
   void add_task_runner( ITaskRunner& runner ) override { scheduler_.add_task_runner( runner ); }
   void add_result_cache( IResultCache& cache ) override { graph_.add_result_cache( cache ); }

--- a/src/runtime/runtimestorage.cc
+++ b/src/runtime/runtimestorage.cc
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 
 #include "handle.hh"
 #include "object.hh"
@@ -40,7 +41,7 @@ string_view RuntimeStorage::get_blob( Handle name )
   } else if ( name.is_local() ) {
     return get<Blob>( local_storage_.at( name.get_local_id() ) );
   } else {
-    Handle local_name = canonical_to_local_.at( Handle( name ) );
+    Handle local_name = canonical_to_local_.get( Handle( name ) );
     return get<Blob>( local_storage_.at( local_name.get_local_id() ) );
   }
 
@@ -54,7 +55,7 @@ string_view RuntimeStorage::user_get_blob( const Handle& name )
   } else if ( name.is_local() ) {
     return get<Blob>( local_storage_.at( name.get_local_id() ) );
   } else {
-    Handle local_name = canonical_to_local_.at( Handle( name ) );
+    Handle local_name = canonical_to_local_.get( Handle( name ) );
     return get<Blob>( local_storage_.at( local_name.get_local_id() ) );
   }
 
@@ -91,7 +92,7 @@ span_view<Handle> RuntimeStorage::get_tree( Handle name )
   if ( name.is_local() ) {
     return get<Tree>( local_storage_.at( name.get_local_id() ) );
   } else {
-    Handle local_name = canonical_to_local_.at( Handle( name ) );
+    Handle local_name = canonical_to_local_.get( Handle( name ) );
     return get<Tree>( local_storage_.at( local_name.get_local_id() ) );
   }
 
@@ -182,7 +183,10 @@ Handle RuntimeStorage::canonicalize( Handle name )
     }
 
     case ContentType::Thunk: {
-      return Handle::get_thunk_name( canonicalize( Handle::get_encode_name( name ) ) ).with_laziness( laziness );
+      Handle new_name = Handle::get_thunk_name( canonicalize( Handle::get_encode_name( name ) ) );
+
+      canonical_to_local_.insert_or_assign( new_name, name );
+      return new_name.with_laziness( laziness );
     }
 
     default:
@@ -200,6 +204,15 @@ filesystem::path RuntimeStorage::get_fix_repo()
     current_directory = current_directory.parent_path();
   }
   return current_directory / ".fix";
+}
+
+optional<Handle> RuntimeStorage::get_local_name( Handle name )
+{
+  if ( !canonical_to_local_.contains( name ) ) {
+    return {};
+  } else {
+    return canonical_to_local_.get( name );
+  }
 }
 
 string RuntimeStorage::serialize( Handle name )
@@ -408,7 +421,7 @@ bool RuntimeStorage::contains( Handle handle )
         if ( not canonical_to_local_.contains( handle.as_strict() ) ) {
           return false;
         }
-        handle = canonical_to_local_.at( handle.as_strict() );
+        handle = canonical_to_local_.get( handle.as_strict() );
       }
       return local_storage_.size() > handle.get_local_id();
     case Laziness::Strict:
@@ -416,7 +429,7 @@ bool RuntimeStorage::contains( Handle handle )
         if ( not canonical_to_local_.contains( handle.as_strict() ) ) {
           return false;
         }
-        handle = canonical_to_local_.at( handle.as_strict() );
+        handle = canonical_to_local_.get( handle.as_strict() );
       }
       // TODO: recurse on children for Tree-like structures
       return local_storage_.size() > handle.get_local_id();

--- a/src/runtime/runtimestorage.cc
+++ b/src/runtime/runtimestorage.cc
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iostream>
 
+#include "handle.hh"
 #include "object.hh"
 #include "operation.hh"
 #include "runtimestorage.hh"
@@ -25,6 +26,11 @@ Handle RuntimeStorage::add_blob( Blob&& blob )
     Handle name( blob );
     return name;
   }
+}
+
+Handle RuntimeStorage::add_canonical_blob( Blob&& blob )
+{
+  return canonicalize( add_blob( move( blob ) ) );
 }
 
 string_view RuntimeStorage::get_blob( Handle name )
@@ -62,12 +68,22 @@ Handle RuntimeStorage::add_tree( Tree&& tree )
   return name;
 }
 
+Handle RuntimeStorage::add_canonical_tree( Tree&& tree )
+{
+  return canonicalize( add_tree( move( tree ) ) );
+}
+
 Handle RuntimeStorage::add_tag( Tree&& tree )
 {
   assert( tree.size() == 3 );
   size_t local_id = local_storage_.push_back( std::move( tree ) );
   Handle name( local_id, tree.size(), ContentType::Tag );
   return name;
+}
+
+Handle RuntimeStorage::add_canonical_tag( Tree&& tree )
+{
+  return canonicalize( add_tag( move( tree ) ) );
 }
 
 span_view<Handle> RuntimeStorage::get_tree( Handle name )

--- a/src/runtime/runtimestorage.cc
+++ b/src/runtime/runtimestorage.cc
@@ -29,11 +29,6 @@ Handle RuntimeStorage::add_blob( Blob&& blob )
   }
 }
 
-Handle RuntimeStorage::add_canonical_blob( Blob&& blob )
-{
-  return canonicalize( add_blob( move( blob ) ) );
-}
-
 string_view RuntimeStorage::get_blob( Handle name )
 {
   if ( name.is_literal_blob() ) {
@@ -69,22 +64,12 @@ Handle RuntimeStorage::add_tree( Tree&& tree )
   return name;
 }
 
-Handle RuntimeStorage::add_canonical_tree( Tree&& tree )
-{
-  return canonicalize( add_tree( move( tree ) ) );
-}
-
 Handle RuntimeStorage::add_tag( Tree&& tree )
 {
   assert( tree.size() == 3 );
   size_t local_id = local_storage_.push_back( std::move( tree ) );
   Handle name( local_id, tree.size(), ContentType::Tag );
   return name;
-}
-
-Handle RuntimeStorage::add_canonical_tag( Tree&& tree )
-{
-  return canonicalize( add_tag( move( tree ) ) );
 }
 
 span_view<Handle> RuntimeStorage::get_tree( Handle name )

--- a/src/runtime/runtimestorage.hh
+++ b/src/runtime/runtimestorage.hh
@@ -46,6 +46,8 @@ private:
 public:
   // add blob
   Handle add_blob( Blob&& blob );
+  // add blob that needs a canonical name
+  Handle add_canonical_blob( Blob&& blob );
 
   // Return reference to blob content
   std::string_view get_blob( Handle name );
@@ -53,9 +55,13 @@ public:
 
   // add Tree
   Handle add_tree( Tree&& tree );
+  // add Tree that needs a canonical name
+  Handle add_canonical_tree( Tree&& tree );
 
   // add Tag
   Handle add_tag( Tree&& tree );
+  // add blob that needs a canonical name
+  Handle add_canonical_tag( Tree&& tree );
 
   // Return reference to Tree
   span_view<Handle> get_tree( Handle name );

--- a/src/runtime/runtimestorage.hh
+++ b/src/runtime/runtimestorage.hh
@@ -28,7 +28,7 @@ class RuntimeStorage
 private:
   friend class RuntimeWorker;
 
-  absl::flat_hash_map<Handle, Handle, AbslHash> canonical_to_local_ {};
+  InMemoryStorage<Handle> canonical_to_local_ {};
   std::unordered_multimap<Handle, std::string> friendly_names_ {};
 
   // Maps a Wasm function Handle to corresponding compiled Program
@@ -79,6 +79,8 @@ public:
 
   Handle canonicalize( Handle name );
 
+  std::optional<Handle> get_local_name( Handle name );
+
   std::string serialize( Handle handle );
   void deserialize();
 
@@ -87,7 +89,7 @@ public:
 
   size_t get_local_storage_size() { return local_storage_.size(); }
 
-  Handle get_local_handle( Handle canonical ) { return canonical_to_local_.at( canonical ); }
+  Handle get_local_handle( Handle canonical ) { return canonical_to_local_.get( canonical ); }
 
   // Tests if the Handle (with the specified accessibility) is valid with the current contents.
   bool contains( Handle handle );

--- a/src/runtime/runtimestorage.hh
+++ b/src/runtime/runtimestorage.hh
@@ -46,8 +46,6 @@ private:
 public:
   // add blob
   Handle add_blob( Blob&& blob );
-  // add blob that needs a canonical name
-  Handle add_canonical_blob( Blob&& blob );
 
   // Return reference to blob content
   std::string_view get_blob( Handle name );
@@ -55,13 +53,9 @@ public:
 
   // add Tree
   Handle add_tree( Tree&& tree );
-  // add Tree that needs a canonical name
-  Handle add_canonical_tree( Tree&& tree );
 
   // add Tag
   Handle add_tag( Tree&& tree );
-  // add blob that needs a canonical name
-  Handle add_canonical_tag( Tree&& tree );
 
   // Return reference to Tree
   span_view<Handle> get_tree( Handle name );

--- a/src/runtime/worker_pool.hh
+++ b/src/runtime/worker_pool.hh
@@ -26,10 +26,7 @@ public:
     }
   }
 
-  std::optional<Info> get_info() override
-  {
-    return Info { .parallelism = static_cast<uint32_t>( std::thread::hardware_concurrency() ) };
-  }
+  std::optional<Info> get_info() override { return Info { .parallelism = static_cast<uint32_t>( num_workers_ ) }; }
 
   std::optional<Handle> start( Task&& task ) override
   {

--- a/src/storage/concurrent_storage.hh
+++ b/src/storage/concurrent_storage.hh
@@ -52,6 +52,13 @@ public:
     return;
   }
 
+  void insert_or_assign( const Handle name, T content )
+  {
+    std::unique_lock lock( name_to_object_mutex_ );
+    name_to_object_.insert_or_assign( name, content );
+    return;
+  }
+
   size_t size()
   {
     std::shared_lock lock( name_to_object_mutex_ );

--- a/src/tester/CMakeLists.txt
+++ b/src/tester/CMakeLists.txt
@@ -16,9 +16,9 @@ target_link_libraries(compiler-tester cryptopp wasmrt absl::flat_hash_map)
 # target_link_libraries(dependency-tester ${FIXPOINT_LIBS})
 # target_link_libraries(dependency-tester cryptopp wasmrt absl::flat_hash_map)
 
-add_executable(network-tester "network-tester.cc" "tester-utils.cc")
-target_link_libraries(network-tester ${FIXPOINT_LIBS})
-target_link_libraries(network-tester wasmrt absl::flat_hash_map)
+#add_executable(network-tester "network-tester.cc" "tester-utils.cc")
+#target_link_libraries(network-tester ${FIXPOINT_LIBS})
+#target_link_libraries(network-tester wasmrt absl::flat_hash_map)
 
 add_executable(fixpoint-server "fixpoint-server.cc" "tester-utils.cc")
 target_link_libraries(fixpoint-server ${FIXPOINT_LIBS})

--- a/src/tester/network-tester.cc
+++ b/src/tester/network-tester.cc
@@ -99,6 +99,16 @@ void client( DummyRuntime& runtime )
   Task t( handle, Operation::Eval );
   runtime.get_runner().start( move( t ) );
 
+  sleep( 1 );
+
+  Tree testing_tree { 3 };
+
+  testing_tree.at( 0 ) = Handle( "Testing entry 0" );
+  testing_tree.at( 1 ) = Handle( "Testing entry 1" );
+  testing_tree.at( 2 ) = Handle( "Testing entry 2" );
+
+  worker.send_tree( testing_tree );
+
   while ( true ) {
     sleep( 1 );
   }


### PR DESCRIPTION
This PR implements the interface for sending objects between nodes:

* `Message` class is separated into `IncomingMessage` and `OutgoingMessage`. `IncomingMessage` can have an Object as payload to copy directly from incoming ring buffer to `aligned_alloc`ed memory. `OutgoingMessage` can have a view as payload to copy directly from backing object data to outgoing ring buffer.
* Each message for sending an object contains the object type (Blob/Tree/Tag) + the content of the object. The receiving side adds and canonicalizes the received objects.
* Before sending `RUN`, always sends the full minimum repository that roots at `task.handle`. Before sending `RESULT`, always sends the full minimum repository that roots at the result handle.
* Guard accesses to `canonical_to_local_` with a mutex.

Closes #106 