### PR TITLE
Handle connection closing

### DIFF
--- a/src/runtime/interface.hh
+++ b/src/runtime/interface.hh
@@ -70,11 +70,12 @@ class IRuntime
 public:
   /**
    * Register an ITaskRunner as a part of this IRuntime's runner pool.  This will make it visible to the
-   * IRuntime's scheduling system.
+   * IRuntime's scheduling system. The IRuntime holds a non-owning pointer to the runner, and the runner may be
+   * destroyed anytime.
    *
    * @param runner  A worker that can run Tasks.
    */
-  virtual void add_task_runner( ITaskRunner& runner ) = 0;
+  virtual void add_task_runner( std::weak_ptr<ITaskRunner> runner ) = 0;
 
   /**
    * Register an IResultCache as part of this IRuntime's notification receipient pool.  This cache will be notified,


### PR DESCRIPTION
* Destruct Remote when connection is closed
* Any pending and future `RUN` message to a closed Remote is forward back to the scheduler
* Scheduler holds a non-owning ptr to Remotes
* Send MessagePayload across workers and NetworkWorker to handle message-type specific logic on the NetworkWorker thread

Closes #113 