### PR TITLE
Compile and test assembly program for future SHA-256 assembly implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0115 NEW)
 
-project(fixpoint)
+project(fixpoint C CXX ASM)
 
 find_package(PkgConfig)
 find_package(Boost 1.74.0 REQUIRED COMPONENTS headers)

--- a/src/tester/CMakeLists.txt
+++ b/src/tester/CMakeLists.txt
@@ -6,6 +6,11 @@ target_link_libraries(stateless-tester runtime)
 add_executable(compiler-tester "compiler-tester.cc" "main.cc" "tester-utils.cc")
 target_link_libraries(compiler-tester runtime)
 
+add_executable(sha-tester "sha-tester.cc" "main.cc")
+target_link_libraries(sha-tester runtime)
+target_link_libraries(sha-tester util)
+
+
 add_executable(fixpoint-server "fixpoint-server.cc" "main.cc" "tester-utils.cc")
 target_link_libraries(fixpoint-server runtime)
 

--- a/src/tester/sha-tester.cc
+++ b/src/tester/sha-tester.cc
@@ -1,0 +1,27 @@
+#include <charconv>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <unistd.h>
+
+#include "base64.hh"
+#include "tester-utils.hh"
+
+#include "sha256.hh"
+#include <glog/logging.h>
+using namespace std;
+
+int min_args = 1;
+int max_args = 1;
+void usage_message( const char* argv0 )
+{
+  cerr << "Usage: " << argv0 << " sha256.cc [label]\n";
+}
+
+void program_body( span_view<char*> )
+{
+  // TBD sha256 tests
+  // Testing sha256.s "hello fixpoint!"
+  hello();
+  cout << "Test for sha256 " << endl;
+}

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,2 +1,2 @@
-file (GLOB LIB_SOURCES "*.cc")
-add_library (util STATIC ${LIB_SOURCES})
+file (GLOB LIB_SOURCES *.cc)
+add_library (util STATIC ${LIB_SOURCES} hello.s)

--- a/src/util/hello.s
+++ b/src/util/hello.s
@@ -1,0 +1,20 @@
+    .global hello
+
+    .section .data
+msg:
+    .ascii "Hello fixpoint!\n"
+len = . - msg
+
+    .section .text
+hello:
+    mov $1, %rax        # syscall number for sys_write
+    mov $1, %rdi        # file descriptor 1 is stdout
+    lea msg(%rip), %rsi      # address of string to output
+    mov $len, %rdx      # number of bytes
+    syscall             # invoke operating system to do the write
+
+    # Exit the program
+    mov $60, %rax       # syscall number for sys_exit
+    xor %rdi, %rdi      # exit code 0
+    syscall             # invoke operating system to exit
+

--- a/src/util/sha256.hh
+++ b/src/util/sha256.hh
@@ -6,3 +6,7 @@ std::string encode( std::string_view input );
 
 bool verify( const std::string& ret, const std::string& input );
 }
+
+extern "C" {
+void hello( void );
+}


### PR DESCRIPTION
- Implement "hello fixpoint!" in assembly
- Created a sha-tester
- CMake now compiles assembly, c, and c++ files