### PR TITLE
Add distributed testing to test cases

### DIFF
--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -9,6 +9,7 @@ add_test(NAME t_add WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/te
 add_test(NAME t_fib WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-fib)
 add_test(NAME t_trap WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/test-trap.sh)
 add_test(NAME t_map WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-map)
+add_test(NAME t_distributed WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-distributed)
 
 add_test(NAME t_add_flatware WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-add-flatware)
 add_test(NAME t_open_flatware WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-open-flatware)

--- a/src/runtime/message.cc
+++ b/src/runtime/message.cc
@@ -6,9 +6,9 @@
 
 using namespace std;
 
-IncomingMessage::IncomingMessage( const Message::Opcode opcode, std::string_view payload )
+IncomingMessage::IncomingMessage( const Message::Opcode opcode, string&& payload )
   : Message( opcode )
-  , payload_( payload )
+  , payload_( std::move( payload ) )
 {}
 
 IncomingMessage::IncomingMessage( const Message::Opcode opcode, OwnedMutBlob&& payload )
@@ -27,6 +27,11 @@ OutgoingMessage::OutgoingMessage( const Message::Opcode opcode, Blob payload )
 {}
 
 OutgoingMessage::OutgoingMessage( const Message::Opcode opcode, Tree payload )
+  : Message( opcode )
+  , payload_( payload )
+{}
+
+OutgoingMessage::OutgoingMessage( const Message::Opcode opcode, string&& payload )
   : Message( opcode )
   , payload_( payload )
 {}

--- a/src/runtime/message.hh
+++ b/src/runtime/message.hh
@@ -103,10 +103,10 @@ using MessagePayload
 
 class IncomingMessage : public Message
 {
-  std::variant<std::string_view, OwnedMutBlob, OwnedMutTree> payload_;
+  std::variant<std::string, OwnedMutBlob, OwnedMutTree> payload_;
 
 public:
-  IncomingMessage( const Message::Opcode opcode, std::string_view payload );
+  IncomingMessage( const Message::Opcode opcode, std::string&& payload );
   IncomingMessage( const Message::Opcode opcode, OwnedMutBlob&& payload );
   IncomingMessage( const Message::Opcode opcode, OwnedMutTree&& payload );
 
@@ -128,11 +128,12 @@ public:
 
 class OutgoingMessage : public Message
 {
-  Object payload_;
+  std::variant<Blob, Tree, std::string> payload_ {};
 
 public:
   OutgoingMessage( const Message::Opcode opcode, Blob payload );
   OutgoingMessage( const Message::Opcode opcode, Tree payload );
+  OutgoingMessage( const Message::Opcode opcode, std::string&& payload );
 
   static OutgoingMessage to_message( MessagePayload&& payload );
   std::string_view payload();

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -207,6 +207,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
     }
 
     case Opcode::INFO: {
+      std::unique_lock lock( info_mutex_ );
       info_ = parse<InfoPayload>( std::get<string>( msg.payload() ) );
       break;
     }

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -167,7 +167,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
   VLOG( 1 ) << "process_incoming_message " << Message::OPCODE_NAMES[static_cast<uint8_t>( msg.opcode() )];
   switch ( msg.opcode() ) {
     case Opcode::RUN: {
-      auto payload = parse<RunPayload>( std::get<string_view>( msg.payload() ) );
+      auto payload = parse<RunPayload>( std::get<string>( msg.payload() ) );
       auto task = payload.task;
       {
         std::unique_lock lock( mutex_ );
@@ -194,7 +194,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
     }
 
     case Opcode::RESULT: {
-      auto payload = parse<ResultPayload>( std::get<string_view>( msg.payload() ) );
+      auto payload = parse<ResultPayload>( std::get<string>( msg.payload() ) );
       pending_result_.erase( payload.task );
       runtime_.finish( std::move( payload.task ), payload.result );
       break;
@@ -207,7 +207,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
     }
 
     case Opcode::INFO: {
-      info_ = parse<InfoPayload>( std::get<string_view>( msg.payload() ) );
+      info_ = parse<InfoPayload>( std::get<string>( msg.payload() ) );
       break;
     }
 
@@ -224,7 +224,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
     }
 
     case Opcode::PROPOSE_TRANSFER: {
-      auto [todo, result, handles] = parse<ProposeTransferPayload>( std::get<string_view>( msg.payload() ) );
+      auto [todo, result, handles] = parse<ProposeTransferPayload>( std::get<string>( msg.payload() ) );
 
       size_t original = handles.size();
       for ( auto it = handles.begin(); it != handles.end(); ) {
@@ -243,7 +243,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
     }
 
     case Opcode::ACCEPT_TRANSFER: {
-      auto [todo, result, handles] = parse<AcceptTransferPayload>( std::get<string_view>( msg.payload() ) );
+      auto [todo, result, handles] = parse<AcceptTransferPayload>( std::get<string>( msg.payload() ) );
 
       VLOG( 2 ) << "Sending " << handles.size() << " objects.";
       for ( const auto& h : handles ) {

--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -3,6 +3,7 @@
 #include <concurrentqueue/concurrentqueue.h>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -59,6 +60,7 @@ class Remote : public ITaskRunner
 
   size_t index_ {};
 
+  std::shared_mutex info_mutex_ {};
   std::optional<ITaskRunner::Info> info_ {};
 
   absl::flat_hash_map<Task, size_t, absl::Hash<Task>>& reply_to_;
@@ -77,7 +79,11 @@ public:
           std::shared_mutex& mutex );
 
   std::optional<Handle> start( Task&& task ) override;
-  std::optional<ITaskRunner::Info> get_info() override { return info_; }
+  std::optional<ITaskRunner::Info> get_info() override
+  {
+    std::shared_lock lock( info_mutex_ );
+    return info_;
+  }
 
   void push_message( OutgoingMessage&& msg );
 

--- a/src/runtime/runtime.hh
+++ b/src/runtime/runtime.hh
@@ -7,10 +7,6 @@
 #include "scheduler.hh"
 #include "worker_pool.hh"
 
-#ifndef RUNTIME_THREADS
-#define RUNTIME_THREADS std::thread::hardware_concurrency()
-#endif
-
 class Runtime : IRuntime
 {
   FixCache cache_;
@@ -23,10 +19,10 @@ class Runtime : IRuntime
   static inline thread_local Handle current_procedure_;
 
 public:
-  Runtime()
+  Runtime( size_t runtime_threads )
     : cache_()
     , storage_()
-    , workers_( std::make_shared<WorkerPool>( RUNTIME_THREADS ) )
+    , workers_( std::make_shared<WorkerPool>( runtime_threads ) )
     , scheduler_( workers_ )
     , graph_( cache_, scheduler_ )
     , network_( *this )
@@ -36,9 +32,9 @@ public:
     workers_->start( *this, graph_, storage_ );
   }
 
-  static Runtime& get_instance()
+  static Runtime& get_instance( size_t runtime_threads = std::thread::hardware_concurrency() )
   {
-    static Runtime runtime;
+    static Runtime runtime( runtime_threads );
     return runtime;
   }
 

--- a/src/runtime/runtimestorage.cc
+++ b/src/runtime/runtimestorage.cc
@@ -398,9 +398,10 @@ bool RuntimeStorage::contains( Handle handle )
 
   shared_lock lock( storage_mutex_ );
 
-  if ( handle.is_thunk() ) {
+  if ( handle.is_thunk() || handle.is_tag() ) {
     return RuntimeStorage::contains( handle.as_tree() );
   }
+
   switch ( handle.get_laziness() ) {
     case Laziness::Lazy:
       return true;
@@ -484,7 +485,6 @@ void RuntimeStorage::visit( Handle handle, function<void( Handle )> visitor )
   } else {
     switch ( handle.get_content_type() ) {
       case ContentType::Tree:
-      case ContentType::Tag:
         if ( contains( handle ) ) {
           for ( const auto& element : get_tree( handle ) ) {
             visit( handle.is_shallow() ? element.as_lazy() : element, visitor );
@@ -496,6 +496,7 @@ void RuntimeStorage::visit( Handle handle, function<void( Handle )> visitor )
         visitor( handle );
         break;
       case ContentType::Thunk:
+      case ContentType::Tag:
         visit( handle.as_tree(), visitor );
         visitor( handle );
         break;

--- a/src/runtime/scheduler.cc
+++ b/src/runtime/scheduler.cc
@@ -17,6 +17,8 @@ void Scheduler::schedule()
 
       size_t i = 0;
       size_t selected = 0;
+
+      std::unique_lock lock( runners_mutex_ );
       for ( auto it = runners_.begin(); it != runners_.end(); ) {
         if ( auto p = it->lock() ) {
           uint32_t cores = p->get_info().value_or( ITaskRunner::Info { .parallelism = 0 } ).parallelism;

--- a/src/tester/fixpoint-client.cc
+++ b/src/tester/fixpoint-client.cc
@@ -19,7 +19,7 @@ void program_body( span_view<char*> args )
 
   args.remove_prefix( 1 ); // ignore argv[ 0 ]
 
-  auto& runtime = Runtime::get_instance();
+  auto& runtime = Runtime::get_instance( RUNTIME_THREADS );
 
   while ( not args.empty() and args[0][0] == '+' ) {
     string addr( &args[0][1] );

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -25,5 +25,8 @@ target_link_libraries(test-map runtime)
 add_executable(test-storage test-storage.cc main.cc)
 target_link_libraries(test-storage runtime)
 
+add_executable(test-distributed test-distributed.cc main.cc)
+target_link_libraries(test-distributed runtime)
+
 add_executable(test-self-host test-self-host.cc main.cc)
 target_link_libraries(test-self-host runtime)

--- a/src/tests/test-distributed.cc
+++ b/src/tests/test-distributed.cc
@@ -1,0 +1,75 @@
+#include "test.hh"
+#include <sys/wait.h>
+
+using namespace std;
+
+Address address( "0.0.0.0", 12345 );
+
+uint32_t fix_add( uint32_t a, uint32_t b, Handle add_elf )
+{
+  Handle add = thunk( tree( { blob( "unused" ), add_elf, a, b } ) );
+  auto& rt = Runtime::get_instance();
+  (void)a, (void)b;
+  Handle result = rt.eval( add );
+  uint32_t x = -1;
+  memcpy( &x, rt.storage().get_blob( result ).data(), sizeof( uint32_t ) );
+  return x;
+}
+
+void check_add( uint32_t a, uint32_t b, Handle add, string name )
+{
+  uint32_t sum_blob = fix_add( a, b, add );
+  printf( "%s: %u + %u = %u\n", name.c_str(), a, b, sum_blob );
+  if ( sum_blob != a + b ) {
+    fprintf( stderr, "%s: got %u + %u = %u, expected %u.\n", name.c_str(), a, b, sum_blob, a + b );
+    exit( 1 );
+  }
+}
+
+void client()
+{
+  auto& rt = Runtime::get_instance( 1 );
+  rt.storage().deserialize();
+  cout << "Client connecting " << endl;
+  rt.connect( address );
+
+  Handle addblob = compile( file( "testing/wasm-examples/addblob.wasm" ) );
+  rt.eval( addblob );
+  Handle add_simple = compile( file( "testing/wasm-examples/add-simple.wasm" ) );
+  rt.eval( add_simple );
+
+  check_add( 7, 8, addblob, "addblob" );
+
+  cout << "Client done" << endl;
+}
+
+void server( int client_pid )
+{
+  (void)client_pid;
+  auto& rt = Runtime::get_instance();
+  rt.storage().deserialize();
+  rt.start_server( address );
+
+  while ( kill( client_pid, 0 ) == 0 ) {
+    sleep( 1 );
+  }
+}
+
+void test( void )
+{
+  auto client_pid = fork();
+  if ( client_pid ) {
+    auto server_pid = fork();
+    if ( server_pid ) {
+      waitpid( client_pid, NULL, 0 );
+      waitpid( server_pid, NULL, 0 );
+    } else {
+      server( client_pid );
+      exit( 0 );
+    }
+  } else {
+    sleep( 1 );
+    client();
+    exit( 0 );
+  }
+}


### PR DESCRIPTION
* Fix several bugs in `Message`: string payload of both incoming and outgoing messages should be owning
* `Tag` is handled in the same way as `Thunk` for `RuntimeStorage::visit` and `RuntimeStorage::contains`
* Guard `NetworkWorker::info_` and `Scheduler::runners_` accesses with mutex
* Add test-distributed

Close #128 