### PR TITLE
Add relations

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -51,7 +51,7 @@ jobs:
       - name: compile
         run: cmake --build out --parallel 8
       - name: download bootstrap seed
-        run: gh release download v0.4.2 --pattern 'bootstrap.zip' --repo 'fix-project/bootstrap'
+        run: gh release download v0.4.3 --pattern 'bootstrap.zip' --repo 'fix-project/bootstrap'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: unzip bootstrap seed

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -24,7 +24,7 @@ After building, copy `./.fix/` to the source directory of Fix.
 ## Way 1: Fetch from Release
 Either
 ```
-wget https://github.com/fix-project/bootstrap/releases/download/v0.4.2/bootstrap.zip
+wget https://github.com/fix-project/bootstrap/releases/download/v0.4.3/bootstrap.zip
 ```
 or use `gh`
 ```

--- a/src/component/handle.cc
+++ b/src/component/handle.cc
@@ -68,7 +68,7 @@ ostream& operator<<( ostream& s, const Handle handle )
     s << "Local=" << handle.get_local_id();
     s << ", ";
   } else {
-    s << "Canonical=" << base16::encode( handle );
+    s << "Canonical=" << base16::encode( handle ).substr( 0, 7 );
     s << ", ";
   }
   s << "Length=" << handle.get_length();

--- a/src/component/handle.cc
+++ b/src/component/handle.cc
@@ -68,7 +68,7 @@ ostream& operator<<( ostream& s, const Handle handle )
     s << "Local=" << handle.get_local_id();
     s << ", ";
   } else {
-    s << "Canonical=" << base16::encode( handle ).substr( 0, 7 );
+    s << "Canonical=" << base16::encode( handle );
     s << ", ";
   }
   s << "Length=" << handle.get_length();

--- a/src/component/object.cc
+++ b/src/component/object.cc
@@ -101,7 +101,7 @@ void Owned<S>::to_file( const std::filesystem::path path ) requires std::is_cons
   VLOG( 1 ) << "writing " << path << " to disk";
   size_t bytes = span_.size_bytes();
   CHECK( not std::filesystem::exists( path ) );
-  int fd = open( path.c_str(), O_RDWR | O_CREAT | O_TRUNC, O_RDWR );
+  int fd = open( path.c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR );
   CHECK( fd >= 0 );
   int status = ftruncate( fd, bytes );
   CHECK( status == 0 );

--- a/src/runtime/elfloader.cc
+++ b/src/runtime/elfloader.cc
@@ -59,6 +59,7 @@ const static map<string, uint64_t> library_func_map
       // { "fixpoint_debug_try_inspect", (uint64_t)fixpoint_debug::try_inspect },
       // { "fixpoint_debug_try_evaluate", (uint64_t)fixpoint_debug::try_evaluate },
       { "fixpoint_lower", (uint64_t)fixpoint::lower },
+      { "fixpoint_trace", (uint64_t)fixpoint::trace },
       { "memcpy", (uint64_t)memcpy },
       { "memmove", (uint64_t)memmove },
       { "memset", (uint64_t)memset },

--- a/src/runtime/elfloader.cc
+++ b/src/runtime/elfloader.cc
@@ -59,7 +59,7 @@ const static map<string, uint64_t> library_func_map
       // { "fixpoint_debug_try_inspect", (uint64_t)fixpoint_debug::try_inspect },
       // { "fixpoint_debug_try_evaluate", (uint64_t)fixpoint_debug::try_evaluate },
       { "fixpoint_lower", (uint64_t)fixpoint::lower },
-      { "fixpoint_trace", (uint64_t)fixpoint::trace },
+      { "fixpoint_pin", (uint64_t)fixpoint::pin },
       { "memcpy", (uint64_t)memcpy },
       { "memmove", (uint64_t)memmove },
       { "memset", (uint64_t)memset },

--- a/src/runtime/fixpointapi.cc
+++ b/src/runtime/fixpointapi.cc
@@ -111,9 +111,9 @@ uint32_t equality( __m256i lhs, __m256i rhs )
   return Runtime::get_instance().storage().compare_handles( left, right );
 }
 
-uint32_t trace( __m256i obj, __m256i trc )
+uint32_t pin( __m256i src, __m256i dst )
 {
-  Runtime::get_instance().trace( Handle( obj ), Handle( trc ) );
+  Runtime::get_instance().pin( Handle( src ), Handle( dst ) );
   return 0;
 }
 

--- a/src/runtime/fixpointapi.cc
+++ b/src/runtime/fixpointapi.cc
@@ -111,6 +111,12 @@ uint32_t equality( __m256i lhs, __m256i rhs )
   return Runtime::get_instance().storage().compare_handles( left, right );
 }
 
+uint32_t trace( __m256i obj, __m256i trc )
+{
+  Runtime::get_instance().trace( Handle( obj ), Handle( trc ) );
+  return 0;
+}
+
 void unsafe_io( int32_t index, int32_t length, wasm_rt_memory_t* mem )
 {
   if ( index + length > (int64_t)mem->size ) {

--- a/src/runtime/fixpointapi.hh
+++ b/src/runtime/fixpointapi.hh
@@ -26,7 +26,7 @@ void unsafe_io( int32_t index, int32_t length, wasm_rt_memory_t* mem );
 
 uint32_t equality( __m256i lhs, __m256i rhs );
 
-uint32_t trace( __m256i obj, __m256i trc );
+uint32_t pin( __m256i src, __m256i dst );
 
 // Length in elements (Tree-like) or bytes (Blobs)
 uint32_t get_length( __m256i handle );

--- a/src/runtime/fixpointapi.hh
+++ b/src/runtime/fixpointapi.hh
@@ -26,6 +26,8 @@ void unsafe_io( int32_t index, int32_t length, wasm_rt_memory_t* mem );
 
 uint32_t equality( __m256i lhs, __m256i rhs );
 
+uint32_t trace( __m256i obj, __m256i trc );
+
 // Length in elements (Tree-like) or bytes (Blobs)
 uint32_t get_length( __m256i handle );
 

--- a/src/runtime/relation.hh
+++ b/src/runtime/relation.hh
@@ -1,26 +1,62 @@
 #pragma once
 
+#include "operation.hh"
 #include "task.hh"
+
+enum class RelationType : uint8_t
+{
+  Apply,
+  Eval,
+  TracedBy,
+  COUNT
+};
+
+static constexpr const char* RELATIONTYPE_NAMES[static_cast<uint8_t>( RelationType::COUNT )]
+  = { "Apply", "Eval", "TracedBy" };
 
 class Relation
 {
-  Task task_;
-  Handle handle_;
+  RelationType type_ {};
+  Handle lhs_;
+  Handle rhs_;
 
 public:
   constexpr Relation( Task task, Handle handle )
-    : task_( task )
-    , handle_( handle )
+    : type_( [&]() {
+      switch ( task.operation() ) {
+        case Operation::Apply:
+          return RelationType::Apply;
+
+        case Operation::Eval:
+          return RelationType::Eval;
+
+        default:
+          throw std::runtime_error( "Invalid task for relation" );
+      }
+    }() )
+    , lhs_( task.handle() )
+    , rhs_( handle )
   {}
 
-  constexpr Task task() const { return task_; }
-  constexpr Handle handle() const { return handle_; }
+  constexpr Relation( Handle obj, Handle trc )
+    : type_( RelationType::TracedBy )
+    , lhs_( obj )
+    , rhs_( trc )
+  {}
 
-  bool operator==( const Relation other ) const { return task_ == other.task() and handle_ == other.handle(); }
+  constexpr RelationType type() const { return type_; }
+  constexpr Handle lhs() const { return lhs_; }
+  constexpr Handle rhs() const { return rhs_; }
+
+  bool operator==( const Relation other ) const
+  {
+    return type_ == other.type() and lhs_ == other.lhs() and rhs_ == other.rhs();
+  }
 
   friend std::ostream& operator<<( std::ostream& s, const Relation relation )
   {
-    s << relation.task() << " --> " << relation.handle();
+    s << relation.lhs() << " --" << RELATIONTYPE_NAMES[static_cast<uint8_t>( relation.type() )] << "--> "
+      << relation.rhs();
     return s;
   }
 };

--- a/src/runtime/relation.hh
+++ b/src/runtime/relation.hh
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "task.hh"
+
+class Relation
+{
+  Task task_;
+  Handle handle_;
+
+public:
+  constexpr Relation( Task task, Handle handle )
+    : task_( task )
+    , handle_( handle )
+  {}
+
+  constexpr Task task() const { return task_; }
+  constexpr Handle handle() const { return handle_; }
+
+  bool operator==( const Relation other ) const { return task_ == other.task() and handle_ == other.handle(); }
+
+  friend std::ostream& operator<<( std::ostream& s, const Relation relation )
+  {
+    s << relation.task() << " --> " << relation.handle();
+    return s;
+  }
+};

--- a/src/runtime/relation.hh
+++ b/src/runtime/relation.hh
@@ -7,12 +7,10 @@ enum class RelationType : uint8_t
 {
   Apply,
   Eval,
-  TracedBy,
   COUNT
 };
 
-static constexpr const char* RELATIONTYPE_NAMES[static_cast<uint8_t>( RelationType::COUNT )]
-  = { "Apply", "Eval", "TracedBy" };
+static constexpr const char* RELATIONTYPE_NAMES[static_cast<uint8_t>( RelationType::COUNT )] = { "Apply", "Eval" };
 
 class Relation
 {
@@ -36,12 +34,6 @@ public:
     }() )
     , lhs_( task.handle() )
     , rhs_( handle )
-  {}
-
-  constexpr Relation( Handle obj, Handle trc )
-    : type_( RelationType::TracedBy )
-    , lhs_( obj )
-    , rhs_( trc )
   {}
 
   constexpr RelationType type() const { return type_; }

--- a/src/runtime/runtime.cc
+++ b/src/runtime/runtime.cc
@@ -1,19 +1,28 @@
 #include "runtime.hh"
+#include "base16.hh"
+#include "relation.hh"
+#include "util.hh"
+#include <filesystem>
 #include <functional>
+#include <stdexcept>
 
 using namespace std;
 
 void Runtime::visit( Relation root, std::function<void( Relation )> visitor )
 {
-  switch ( root.task().operation() ) {
-    case Operation::Apply:
-    case Operation::Fill:
-      VLOG( 1 ) << "Visiting apply/fill";
+  switch ( root.type() ) {
+    case RelationType::Apply:
+      VLOG( 1 ) << "Visiting apply";
       break;
 
-    case Operation::Eval: {
+    case RelationType::TracedBy:
+    case RelationType::COUNT:
+      throw std::runtime_error( "Visiting not-visitable relation" );
+      break;
+
+    case RelationType::Eval: {
       VLOG( 1 ) << "Visiting eval";
-      auto name = root.task().handle();
+      auto name = root.lhs();
 
       switch ( name.get_content_type() ) {
         case ContentType::Blob:
@@ -37,13 +46,13 @@ void Runtime::visit( Relation root, std::function<void( Relation )> visitor )
             return;
           visit( relation.value(), visitor );
 
-          relation = get_relation( Task::Apply( relation->handle() ) );
+          relation = get_relation( Task::Apply( relation->rhs() ) );
           if ( !relation.has_value() )
             return;
           visit( relation.value(), visitor );
 
           relation = get_relation(
-            Task::Eval( name.is_shallow() ? Handle::make_shallow( relation->handle() ) : relation->handle() ) );
+            Task::Eval( name.is_shallow() ? Handle::make_shallow( relation->rhs() ) : relation->rhs() ) );
           if ( !relation.has_value() )
             return;
           visit( relation.value(), visitor );
@@ -56,11 +65,119 @@ void Runtime::visit( Relation root, std::function<void( Relation )> visitor )
   visitor( root );
 }
 
+void Runtime::shallow_visit( Relation root, std::function<void( Relation )> visitor )
+{
+  switch ( root.type() ) {
+    case RelationType::Apply:
+      VLOG( 1 ) << "Visiting apply";
+      break;
+
+    case RelationType::TracedBy:
+    case RelationType::COUNT:
+      throw std::runtime_error( "Visiting not-visitable relation" );
+      break;
+
+    case RelationType::Eval: {
+      VLOG( 1 ) << "Visiting eval";
+      auto name = root.lhs();
+
+      switch ( name.get_content_type() ) {
+        case ContentType::Blob:
+          break;
+
+        case ContentType::Tree:
+        case ContentType::Tag: {
+          for ( const auto entry : storage_.get_tree( name.as_tree() ) ) {
+            if ( auto relation = get_relation( Task::Eval( entry ) ); relation.has_value() ) {
+              visitor( relation.value() );
+            }
+          }
+          break;
+        }
+
+        case ContentType::Thunk: {
+          Handle encode = name.as_tree();
+
+          auto relation = get_relation( Task::Eval( encode ) );
+          if ( !relation.has_value() )
+            return;
+          visitor( relation.value() );
+
+          relation = get_relation( Task::Apply( relation->rhs() ) );
+          if ( !relation.has_value() )
+            return;
+          visitor( relation.value() );
+
+          relation = get_relation(
+            Task::Eval( name.is_shallow() ? Handle::make_shallow( relation->rhs() ) : relation->rhs() ) );
+          if ( !relation.has_value() )
+            return;
+          visitor( relation.value() );
+          break;
+        }
+      }
+    }
+  }
+}
+
 void Runtime::serialize( Task task )
 {
   if ( auto relation = cache_.get_relation( task ); relation.has_value() ) {
     VLOG( 1 ) << "Visiting relations" << endl;
-    visit( relation.value(), [this]( Relation relation ) { this->storage().serialize( relation ); } );
+    visit( relation.value(), [this]( Relation relation ) {
+      this->storage().serialize_relation( relation );
+      this->serialize( relation.lhs() );
+      this->serialize( relation.rhs() );
+    } );
   }
+}
+
+void Runtime::serialize( Handle name )
+{
+  storage_.visit( name, [this]( Handle handle ) {
+    this->storage().serialize_object( handle, this->storage().get_fix_repo() / "objects" );
+    auto trace_relations = cache_.get_relation( handle );
+    for ( const auto& relation : trace_relations ) {
+      this->storage().serialize_relation( relation );
+      storage_.visit( relation.rhs(), [this]( Handle handle ) {
+        this->storage().serialize_object( handle, this->storage().get_fix_repo() / "objects" );
+      } );
+    }
+  } );
+}
+
+void Runtime::deserialize_relations()
+{
+  auto dir = storage_.get_fix_repo() / "relations";
+  if ( not filesystem::exists( dir ) ) {
+    return;
+  }
+
+  for ( const auto& file :
+        filesystem::directory_iterator( dir / RELATIONTYPE_NAMES[to_underlying( RelationType::Apply )] ) ) {
+    Handle name( base16::decode( file.path().filename().string() ) );
+
+    auto tmp = OwnedTree::from_file( file );
+    cache_.finish( Task::Apply( name ), tmp.at( 0 ) );
+  }
+
+  for ( const auto& file :
+        filesystem::directory_iterator( dir / RELATIONTYPE_NAMES[to_underlying( RelationType::Eval )] ) ) {
+    Handle name( base16::decode( file.path().filename().string() ) );
+
+    auto tmp = OwnedTree::from_file( file );
+    cache_.finish( Task::Eval( name ), tmp.at( 0 ) );
+  }
+
+  for ( const auto& file :
+        filesystem::directory_iterator( dir / RELATIONTYPE_NAMES[to_underlying( RelationType::TracedBy )] ) ) {
+    Handle name( base16::decode( file.path().filename().string() ) );
+
+    auto tmp = OwnedTree::from_file( file );
+    for ( const auto& entry : tmp.span() ) {
+      cache_.trace( name, entry );
+    }
+  }
+
   return;
 }

--- a/src/runtime/runtime.cc
+++ b/src/runtime/runtime.cc
@@ -1,0 +1,66 @@
+#include "runtime.hh"
+#include <functional>
+
+using namespace std;
+
+void Runtime::visit( Relation root, std::function<void( Relation )> visitor )
+{
+  switch ( root.task().operation() ) {
+    case Operation::Apply:
+    case Operation::Fill:
+      VLOG( 1 ) << "Visiting apply/fill";
+      break;
+
+    case Operation::Eval: {
+      VLOG( 1 ) << "Visiting eval";
+      auto name = root.task().handle();
+
+      switch ( name.get_content_type() ) {
+        case ContentType::Blob:
+          break;
+
+        case ContentType::Tree:
+        case ContentType::Tag: {
+          for ( const auto entry : storage_.get_tree( name.as_tree() ) ) {
+            if ( auto relation = get_relation( Task::Eval( entry ) ); relation.has_value() ) {
+              visit( relation.value(), visitor );
+            }
+          }
+          break;
+        }
+
+        case ContentType::Thunk: {
+          Handle encode = name.as_tree();
+
+          auto relation = get_relation( Task::Eval( encode ) );
+          if ( !relation.has_value() )
+            return;
+          visit( relation.value(), visitor );
+
+          relation = get_relation( Task::Apply( relation->handle() ) );
+          if ( !relation.has_value() )
+            return;
+          visit( relation.value(), visitor );
+
+          relation = get_relation(
+            Task::Eval( name.is_shallow() ? Handle::make_shallow( relation->handle() ) : relation->handle() ) );
+          if ( !relation.has_value() )
+            return;
+          visit( relation.value(), visitor );
+          break;
+        }
+      }
+    }
+  }
+  VLOG( 1 ) << "Calling visitor " << root;
+  visitor( root );
+}
+
+void Runtime::serialize( Task task )
+{
+  if ( auto relation = cache_.get_relation( task ); relation.has_value() ) {
+    VLOG( 1 ) << "Visiting relations" << endl;
+    visit( relation.value(), [this]( Relation relation ) { this->storage().serialize( relation ); } );
+  }
+  return;
+}

--- a/src/runtime/runtime.hh
+++ b/src/runtime/runtime.hh
@@ -63,6 +63,7 @@ public:
 
   std::optional<Relation> get_relation( Task task ) { return cache_.get_relation( task ); }
   std::list<Relation> get_relation( Handle handle ) { return cache_.get_relation( handle ); }
+  std::list<Relation> get_parents( Handle handle ) { return cache_.get_parents( handle ); }
 
   void set_current_procedure( Handle handle ) { current_procedure_ = handle; }
 

--- a/src/runtime/runtime.hh
+++ b/src/runtime/runtime.hh
@@ -19,7 +19,7 @@ class Runtime : IRuntime
 
   static inline thread_local Handle current_procedure_;
 
-  void visit( Relation root, std::function<void( Relation )> visitor );
+  void deserialize_relations();
 
 public:
   Runtime( size_t runtime_threads )
@@ -62,6 +62,7 @@ public:
   Handle eval( Handle target ) { return graph_.run( Task::Eval( target ) ); }
 
   std::optional<Relation> get_relation( Task task ) { return cache_.get_relation( task ); }
+  std::list<Relation> get_relation( Handle handle ) { return cache_.get_relation( handle ); }
 
   void set_current_procedure( Handle handle ) { current_procedure_ = handle; }
 
@@ -79,5 +80,17 @@ public:
     network_.stop();
   }
 
+  void visit( Relation root, std::function<void( Relation )> visitor );
+  void shallow_visit( Relation root, std::function<void( Relation )> visitor );
+
   void serialize( Task task );
+  void serialize( Handle name );
+
+  void deserialize()
+  {
+    storage_.deserialize();
+    deserialize_relations();
+  };
+
+  void trace( Handle obj, Handle trc ) { cache_.trace( obj, trc ); }
 };

--- a/src/runtime/runtime.hh
+++ b/src/runtime/runtime.hh
@@ -3,6 +3,7 @@
 #include "dependency_graph.hh"
 #include "interface.hh"
 #include "network.hh"
+#include "relation.hh"
 #include "runtimestorage.hh"
 #include "scheduler.hh"
 #include "worker_pool.hh"
@@ -17,6 +18,8 @@ class Runtime : IRuntime
   NetworkWorker network_;
 
   static inline thread_local Handle current_procedure_;
+
+  void visit( Relation root, std::function<void( Relation )> visitor );
 
 public:
   Runtime( size_t runtime_threads )
@@ -58,6 +61,8 @@ public:
 
   Handle eval( Handle target ) { return graph_.run( Task::Eval( target ) ); }
 
+  std::optional<Relation> get_relation( Task task ) { return cache_.get_relation( task ); }
+
   void set_current_procedure( Handle handle ) { current_procedure_ = handle; }
 
   Handle get_current_procedure() { return current_procedure_; }
@@ -73,4 +78,6 @@ public:
     workers_->stop();
     network_.stop();
   }
+
+  void serialize( Task task );
 };

--- a/src/runtime/runtimestorage.cc
+++ b/src/runtime/runtimestorage.cc
@@ -400,22 +400,22 @@ void RuntimeStorage::deserialize_objects( const filesystem::path& dir )
 
     switch ( name.get_content_type() ) {
       case ContentType::Blob: {
-                                add_blob( OwnedBlob::from_file( file ), name );
-                                break;
-                              }
+        add_blob( OwnedBlob::from_file( file ), name );
+        break;
+      }
 
       case ContentType::Tree: {
-                                add_tree( OwnedTree::from_file( file ), name );
-                                break;
-                              }
+        add_tree( OwnedTree::from_file( file ), name );
+        break;
+      }
 
       case ContentType::Thunk:
       case ContentType::Tag: {
-                               break;
-                             }
+        break;
+      }
 
       default:
-                             break;
+        break;
     }
   }
 }

--- a/src/runtime/runtimestorage.cc
+++ b/src/runtime/runtimestorage.cc
@@ -308,7 +308,14 @@ void RuntimeStorage::serialize_object( Handle name, const filesystem::path& dir 
       return;
     }
 
-    case ContentType::Tag:
+    case ContentType::Tag: {
+      if ( not std::filesystem::exists( dir / file_name ) ) {
+        string tree_file_name = base16::encode( new_name.as_tree() );
+        filesystem::create_symlink( dir / tree_file_name, dir / file_name );
+      }
+      return;
+    }
+
     case ContentType::Thunk: {
       return;
     }

--- a/src/runtime/runtimestorage.hh
+++ b/src/runtime/runtimestorage.hh
@@ -56,7 +56,7 @@ private:
   void schedule( Task task );
 
   std::filesystem::path get_fix_repo();
-  void serialize_objects( Handle name, const std::filesystem::path& dir );
+  void serialize_object( Handle name, const std::filesystem::path& dir );
   void deserialize_objects( const std::filesystem::path& dir );
 
   Handle canonicalize( Handle handle, std::unique_lock<std::shared_mutex>& lock );
@@ -88,6 +88,8 @@ public:
 
   void serialize( Handle handle );
   void deserialize();
+
+  void serialize( Relation relation );
 
   // Tests if the Handle (with the specified accessibility) is valid with the current contents.
   bool contains( Handle handle );

--- a/src/runtime/runtimestorage.hh
+++ b/src/runtime/runtimestorage.hh
@@ -55,14 +55,15 @@ private:
 
   void schedule( Task task );
 
-  std::filesystem::path get_fix_repo();
-  void serialize_object( Handle name, const std::filesystem::path& dir );
   void deserialize_objects( const std::filesystem::path& dir );
+  void deserialize_relations( const std::filesystem::path& dir );
 
   Handle canonicalize( Handle handle, std::unique_lock<std::shared_mutex>& lock );
 
 public:
   RuntimeStorage() { canonical_storage_.reserve( 1024 ); }
+
+  std::filesystem::path get_fix_repo();
 
   // Take ownership of a mutable Blob
   Handle add_blob( OwnedMutBlob&& blob );
@@ -86,10 +87,10 @@ public:
 
   Task canonicalize( Task task );
 
-  void serialize( Handle handle );
   void deserialize();
 
-  void serialize( Relation relation );
+  void serialize_object( Handle name, const std::filesystem::path& dir );
+  void serialize_relation( Relation relation );
 
   // Tests if the Handle (with the specified accessibility) is valid with the current contents.
   bool contains( Handle handle );

--- a/src/storage/fixcache.hh
+++ b/src/storage/fixcache.hh
@@ -11,6 +11,9 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/hash/hash.h"
+#include "handle.hh"
+#include "operation.hh"
+#include "relation.hh"
 #include "task.hh"
 
 #include "interface.hh"
@@ -63,6 +66,19 @@ public:
     std::shared_lock lock( mutex_ );
     if ( cache_.contains( task ) )
       return cache_.at( task );
+    return {};
+  }
+
+  std::optional<Relation> get_relation( Task task )
+  {
+    std::shared_lock lock( mutex_ );
+    if ( cache_.contains( task ) )
+      return Relation( task, cache_.at( task ) );
+
+    if ( task.operation() == Operation::Eval && task.handle().is_blob() ) {
+      return Relation( task, task.handle() );
+    }
+
     return {};
   }
 

--- a/src/storage/fixcache.hh
+++ b/src/storage/fixcache.hh
@@ -95,6 +95,19 @@ public:
     return result;
   }
 
+  std::list<Relation> get_parents( Handle handle )
+  {
+    std::shared_lock lock( mutex_ );
+
+    std::list<Relation> result;
+    for ( const auto& [task, res] : cache_ ) {
+      if ( res == handle ) {
+        result.push_back( Relation( task, res ) );
+      }
+    }
+    return result;
+  }
+
   /**
    * Tests if FixCache has already seen the result of running a task.  Semantically equivalent to
    * `get(task).has_value()`.

--- a/src/tester/CMakeLists.txt
+++ b/src/tester/CMakeLists.txt
@@ -6,6 +6,9 @@ target_link_libraries(stateless-tester runtime)
 add_executable(rw-tester "rw-tester.cc" "main.cc" "tester-utils.cc")
 target_link_libraries(rw-tester runtime)
 
+add_executable(fix "fix.cc" "main.cc" "tester-utils.cc")
+target_link_libraries(fix runtime)
+
 add_executable(compiler-tester "compiler-tester.cc" "main.cc" "tester-utils.cc")
 target_link_libraries(compiler-tester runtime)
 

--- a/src/tester/CMakeLists.txt
+++ b/src/tester/CMakeLists.txt
@@ -1,7 +1,10 @@
 include_directories(${CMAKE_BINARY_DIR}/src/runtime)
 
-add_executable(stateless-tester "stateless-tester.cc" "main.cc" "main.cc" "tester-utils.cc")
+add_executable(stateless-tester "stateless-tester.cc" "main.cc" "tester-utils.cc")
 target_link_libraries(stateless-tester runtime)
+
+add_executable(rw-tester "rw-tester.cc" "main.cc" "tester-utils.cc")
+target_link_libraries(rw-tester runtime)
 
 add_executable(compiler-tester "compiler-tester.cc" "main.cc" "tester-utils.cc")
 target_link_libraries(compiler-tester runtime)

--- a/src/tester/compiler-tester.cc
+++ b/src/tester/compiler-tester.cc
@@ -63,7 +63,7 @@ void program_body( span_view<char*> args )
     storage.set_ref( *ref_name, result );
   }
   Handle canonical = storage.canonicalize( result );
-  storage.serialize( result );
+  rt.serialize( result );
   // print the result
   cout << "Result serialized to: " << base16::encode( canonical ) << "\n";
   if ( ref_name ) {

--- a/src/tester/fix.cc
+++ b/src/tester/fix.cc
@@ -30,6 +30,8 @@ void usage_message( const char* argv0 )
   cerr << "   entry :=   file:<filename>\n";
   cerr << "            | string:<string>\n";
   cerr << "            | name:<base16-encoded name>\n";
+  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = (B)lob | "
+          "(T)ree | Thun(K) | Ta(G)\n";
   cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
   cerr << "            | tree:<n> (followed by <n> entries)\n";
   cerr << "            | thunk: (followed by tree:<n>)\n";

--- a/src/tester/fix.cc
+++ b/src/tester/fix.cc
@@ -1,0 +1,136 @@
+#include "base16.hh"
+#include "handle.hh"
+#include "runtimestorage.hh"
+#include "spans.hh"
+#include "tester-utils.hh"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace std;
+
+void usage_message( const char* argv0 )
+{
+  cerr << "Usage: " << argv0 << " commands...\n";
+  cerr << "   command (followed by entry) :=   what:\n";
+  cerr << "                                    -- print the handle to the object\n";
+  cerr << "                                  | deep-content:\n";
+  cerr << "                                    -- print content of the object\n";
+  cerr << "                                  | content:\n";
+  cerr << "                                    -- same as content but does not print tree content recursively\n";
+  cerr << "                                  | result-<operation>: (with <operation> = apply | eval)\n";
+  cerr << "                                    -- print the result of eval/apply(object) if known\n";
+  cerr << "                                  | steps-eval:\n";
+  cerr << "                                    -- print all dependencies of an eval-relation\n";
+  cerr << "                                  | step-eval:\n";
+  cerr << "                                    -- print the immediate dependencies of an eval-relation\n";
+  cerr << "                                  | trace:\n";
+  cerr << "                                    -- print all trace entries for the object\n";
+  cerr << "   entry :=   file:<filename>\n";
+  cerr << "            | string:<string>\n";
+  cerr << "            | name:<base16-encoded name>\n";
+  cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
+  cerr << "            | tree:<n> (followed by <n> entries)\n";
+  cerr << "            | thunk: (followed by tree:<n>)\n";
+  cerr << "            | compile:<filename>\n";
+  cerr << "            | ref:<ref>\n";
+}
+
+int min_args = 2;
+int max_args = -1;
+
+void parse_args( span_view<char*> args )
+{
+  if ( args.size() == 0 )
+    return;
+
+  auto& rt = Runtime::get_instance( 0 );
+
+  vector<ReadOnlyFile> open_files;
+
+  string_view str { args[0] };
+  args.remove_prefix( 1 );
+  Handle handle = parse_args( args, open_files, true );
+
+  if ( str.starts_with( "what:" ) ) {
+    cout << rt.storage().get_display_name( handle ) << endl;
+    return;
+  }
+
+  if ( str.starts_with( "deep-content:" ) ) {
+    if ( not rt.storage().contains( handle ) ) {
+      cerr << "Object does not exist\n";
+      return;
+    }
+    cout << deep_pretty_print( handle );
+    return;
+  }
+
+  if ( str.starts_with( "content:" ) ) {
+    if ( not rt.storage().contains( handle ) ) {
+      cerr << "Object does not exist\n";
+      return;
+    }
+    cout << pretty_print( handle );
+    return;
+  }
+
+  if ( str.starts_with( "result-" ) ) {
+    str.remove_prefix( 7 );
+
+    optional<Relation> relation;
+    if ( str.starts_with( "apply:" ) ) {
+      relation = rt.get_relation( Task::Apply( handle ) );
+    } else if ( str.starts_with( "eval:" ) ) {
+      relation = rt.get_relation( Task::Eval( handle ) );
+    } else {
+      cerr << "Cannot parse command\n";
+      return;
+    }
+
+    if ( not relation.has_value() ) {
+      cerr << "Relation does not exist\n";
+      return;
+    }
+
+    cout << relation.value() << endl;
+    return;
+  }
+
+  if ( str.starts_with( "step-eval:" ) ) {
+    auto relation = rt.get_relation( Task::Eval( handle ) );
+
+    if ( not relation.has_value() ) {
+      cerr << "Relation does not exist\n";
+      return;
+    }
+    rt.shallow_visit( relation.value(), []( Relation relation ) { cout << relation << endl; } );
+    return;
+  }
+
+  if ( str.starts_with( "steps-eval:" ) ) {
+    auto relation = rt.get_relation( Task::Eval( handle ) );
+
+    if ( not relation.has_value() ) {
+      cerr << "Relation does not exist\n";
+      return;
+    }
+    rt.visit( relation.value(), []( Relation relation ) { cout << relation << endl; } );
+    return;
+  }
+
+  if ( str.starts_with( "trace:" ) ) {
+    auto relations = rt.get_relation( handle );
+    for ( const auto& relation : relations ) {
+      cout << deep_pretty_print( relation.rhs() );
+    }
+    return;
+  }
+}
+
+void program_body( span_view<char*> args )
+{
+  args.remove_prefix( 1 );
+  parse_args( args );
+}

--- a/src/tester/fix.cc
+++ b/src/tester/fix.cc
@@ -36,6 +36,7 @@ void usage_message( const char* argv0 )
   cerr << "            | thunk: (followed by tree:<n>)\n";
   cerr << "            | compile:<filename>\n";
   cerr << "            | ref:<ref>\n";
+  cerr << "\U0001F4AC means there are more explanations. If it follows a Handle, use \"explain:\". If it follows a Relation, use \"step-eval:\"\n";
 }
 
 int min_args = 2;

--- a/src/tester/fix.cc
+++ b/src/tester/fix.cc
@@ -15,10 +15,10 @@ void usage_message( const char* argv0 )
   cerr << "Usage: " << argv0 << " commands...\n";
   cerr << "   command (followed by entry) :=   what:\n";
   cerr << "                                    -- print the handle to the object\n";
-  cerr << "                                  | deep-content:\n";
-  cerr << "                                    -- print content of the object\n";
   cerr << "                                  | content:\n";
-  cerr << "                                    -- same as content but does not print tree content recursively\n";
+  cerr << "                                    -- print content of the object\n";
+  cerr << "                                  | deep-content:\n";
+  cerr << "                                    -- same as content but prints tree content recursively\n";
   cerr << "                                  | result-<operation>: (with <operation> = apply | eval)\n";
   cerr << "                                    -- print the result of eval/apply(object) if known\n";
   cerr << "                                  | steps-eval:\n";
@@ -27,11 +27,13 @@ void usage_message( const char* argv0 )
   cerr << "                                    -- print the immediate dependencies of an eval-relation\n";
   cerr << "                                  | trace:\n";
   cerr << "                                    -- print all trace entries for the object\n";
+  cerr << "                                  | from-where:\n";
+  cerr << "                                    -- print all eval/apply-relations that leads to the object\n";
   cerr << "   entry :=   file:<filename>\n";
   cerr << "            | string:<string>\n";
   cerr << "            | name:<base16-encoded name>\n";
-  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = (B)lob | "
-          "(T)ree | Thun(K) | Ta(G)\n";
+  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = Blo(B) | "
+          "Tre(E) | Thun(K) | Ta(G)\n";
   cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
   cerr << "            | tree:<n> (followed by <n> entries)\n";
   cerr << "            | thunk: (followed by tree:<n>)\n";
@@ -126,6 +128,19 @@ void parse_args( span_view<char*> args )
     auto relations = rt.get_relation( handle );
     for ( const auto& relation : relations ) {
       cout << deep_pretty_print( relation.rhs() );
+    }
+    return;
+  }
+
+  if ( str.starts_with( "from-where:" ) ) {
+    auto relations = rt.get_parents( handle );
+    if ( relations.empty() ) {
+      cout << "Relation does not exist\n";
+      return;
+    }
+
+    for ( const auto& relation : relations ) {
+      cout << relation << endl;
     }
     return;
   }

--- a/src/tester/rw-tester.cc
+++ b/src/tester/rw-tester.cc
@@ -51,6 +51,8 @@ void usage_message( const char* argv0 )
   cerr << "   entry :=   file:<filename>\n";
   cerr << "            | string:<string>\n";
   cerr << "            | name:<base16-encoded name>\n";
+  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = (B)lob | "
+          "(T)ree | Thun(K) | Ta(G)\n";
   cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
   cerr << "            | tree:<n> (followed by <n> entries)\n";
   cerr << "            | thunk: (followed by tree:<n>)\n";

--- a/src/tester/rw-tester.cc
+++ b/src/tester/rw-tester.cc
@@ -1,0 +1,61 @@
+#include <charconv>
+#include <cstdlib>
+#include <iostream>
+#include <unistd.h>
+
+#include "tester-utils.hh"
+
+using namespace std;
+
+int min_args = 2;
+int max_args = -1;
+
+void program_body( span_view<char*> args )
+{
+  ios::sync_with_stdio( false );
+  vector<ReadOnlyFile> open_files;
+
+  args.remove_prefix( 1 ); // ignore argv[ 0 ]
+
+  // make the combination from the given arguments
+  Handle encode_name = parse_args( args, open_files );
+
+  if ( not args.empty() ) {
+    throw runtime_error( "unexpected argument: "s + args.at( 0 ) );
+  }
+
+  // add the combination to the store, and print it
+  cout << "Combination:\n" << pretty_print( encode_name ) << "\n";
+
+  auto& runtime = Runtime::get_instance();
+
+  // make a Thunk that points to the combination
+  Handle thunk_name = encode_name.as_thunk();
+
+  // force the Thunk and print it
+  Handle result = runtime.eval( thunk_name );
+
+  // print the result
+  cout << "Result:\n" << pretty_print( result );
+
+  runtime.serialize( Task::Eval( thunk_name ) );
+  runtime.storage().serialize( thunk_name );
+  runtime.storage().serialize( result );
+
+  Handle canonical_thunk_name = runtime.storage().canonicalize( thunk_name );
+  Handle canonical_result_name = runtime.storage().canonicalize( result );
+  cout << "Eval: " << canonical_thunk_name << " --> " << canonical_result_name << endl;
+}
+
+void usage_message( const char* argv0 )
+{
+  cerr << "Usage: " << argv0 << " entry...\n";
+  cerr << "   entry :=   file:<filename>\n";
+  cerr << "            | string:<string>\n";
+  cerr << "            | name:<base16-encoded name>\n";
+  cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
+  cerr << "            | tree:<n> (followed by <n> entries)\n";
+  cerr << "            | thunk: (followed by tree:<n>)\n";
+  cerr << "            | compile:<filename>\n";
+  cerr << "            | ref:<ref>\n";
+}

--- a/src/tester/rw-tester.cc
+++ b/src/tester/rw-tester.cc
@@ -51,8 +51,7 @@ void usage_message( const char* argv0 )
   cerr << "   entry :=   file:<filename>\n";
   cerr << "            | string:<string>\n";
   cerr << "            | name:<base16-encoded name>\n";
-  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = Blo(B) | "
-          "Tre(E) | Thun(K) | Ta(G)\n";
+  cerr << "            | short-name:<7 bytes shortened base16-encoded name>\n";
   cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
   cerr << "            | tree:<n> (followed by <n> entries)\n";
   cerr << "            | thunk: (followed by tree:<n>)\n";

--- a/src/tester/rw-tester.cc
+++ b/src/tester/rw-tester.cc
@@ -25,7 +25,7 @@ void program_body( span_view<char*> args )
   }
 
   // add the combination to the store, and print it
-  cout << "Combination:\n" << pretty_print( encode_name ) << "\n";
+  cout << "Combination:\n" << deep_pretty_print( encode_name ) << "\n";
 
   auto& runtime = Runtime::get_instance();
 
@@ -36,11 +36,9 @@ void program_body( span_view<char*> args )
   Handle result = runtime.eval( thunk_name );
 
   // print the result
-  cout << "Result:\n" << pretty_print( result );
+  cout << "Result:\n" << deep_pretty_print( result );
 
   runtime.serialize( Task::Eval( thunk_name ) );
-  runtime.storage().serialize( thunk_name );
-  runtime.storage().serialize( result );
 
   Handle canonical_thunk_name = runtime.storage().canonicalize( thunk_name );
   Handle canonical_result_name = runtime.storage().canonicalize( result );

--- a/src/tester/rw-tester.cc
+++ b/src/tester/rw-tester.cc
@@ -51,8 +51,8 @@ void usage_message( const char* argv0 )
   cerr << "   entry :=   file:<filename>\n";
   cerr << "            | string:<string>\n";
   cerr << "            | name:<base16-encoded name>\n";
-  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = (B)lob | "
-          "(T)ree | Thun(K) | Ta(G)\n";
+  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = Blo(B) | "
+          "Tre(E) | Thun(K) | Ta(G)\n";
   cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
   cerr << "            | tree:<n> (followed by <n> entries)\n";
   cerr << "            | thunk: (followed by tree:<n>)\n";

--- a/src/tester/stateless-tester.cc
+++ b/src/tester/stateless-tester.cc
@@ -25,7 +25,7 @@ void program_body( span_view<char*> args )
   }
 
   // add the combination to the store, and print it
-  cout << "Combination:\n" << pretty_print( encode_name ) << "\n";
+  cout << "Combination:\n" << deep_pretty_print( encode_name ) << "\n";
 
   auto& runtime = Runtime::get_instance();
 
@@ -36,7 +36,7 @@ void program_body( span_view<char*> args )
   Handle result = runtime.eval( thunk_name );
 
   // print the result
-  cout << "Result:\n" << pretty_print( result );
+  cout << "Result:\n" << deep_pretty_print( result );
 }
 
 void usage_message( const char* argv0 )

--- a/src/tester/stateless-tester.cc
+++ b/src/tester/stateless-tester.cc
@@ -45,6 +45,8 @@ void usage_message( const char* argv0 )
   cerr << "   entry :=   file:<filename>\n";
   cerr << "            | string:<string>\n";
   cerr << "            | name:<base16-encoded name>\n";
+  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = (B)lob | "
+          "(T)ree | Thun(K) | Ta(G)\n";
   cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
   cerr << "            | tree:<n> (followed by <n> entries)\n";
   cerr << "            | thunk: (followed by tree:<n>)\n";

--- a/src/tester/stateless-tester.cc
+++ b/src/tester/stateless-tester.cc
@@ -45,8 +45,7 @@ void usage_message( const char* argv0 )
   cerr << "   entry :=   file:<filename>\n";
   cerr << "            | string:<string>\n";
   cerr << "            | name:<base16-encoded name>\n";
-  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = Blo(B) | "
-          "Tre(E) | Thun(K) | Ta(G)\n";
+  cerr << "            | short-name:<7 bytes shortened base16-encoded name>\n";
   cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
   cerr << "            | tree:<n> (followed by <n> entries)\n";
   cerr << "            | thunk: (followed by tree:<n>)\n";

--- a/src/tester/stateless-tester.cc
+++ b/src/tester/stateless-tester.cc
@@ -45,8 +45,8 @@ void usage_message( const char* argv0 )
   cerr << "   entry :=   file:<filename>\n";
   cerr << "            | string:<string>\n";
   cerr << "            | name:<base16-encoded name>\n";
-  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = (B)lob | "
-          "(T)ree | Thun(K) | Ta(G)\n";
+  cerr << "            | short-name:<prefix><first 7 bytes of a base16-encoded name> (with <prefix> = Blo(B) | "
+          "Tre(E) | Thun(K) | Ta(G)\n";
   cerr << "            | uint<n>:<integer> (with <n> = 8 | 16 | 32 | 64)\n";
   cerr << "            | tree:<n> (followed by <n> entries)\n";
   cerr << "            | thunk: (followed by tree:<n>)\n";

--- a/src/tester/tester-utils.cc
+++ b/src/tester/tester-utils.cc
@@ -34,9 +34,15 @@ Handle make_blob( T t ) requires std::is_integral_v<T>
  * Adds the args to RuntimeStorage, loading files and creating objects as necessary.
  * The contents of @p open_files must outlive this RuntimeStorage instance.
  */
-Handle parse_args( span_view<char*>& args, vector<ReadOnlyFile>& open_files )
+Handle parse_args( span_view<char*>& args, vector<ReadOnlyFile>& open_files, bool deserialize )
 {
-  auto& runtime = Runtime::get_instance().storage();
+  auto& rt = Runtime::get_instance();
+  auto& storage = Runtime::get_instance().storage();
+
+  if ( deserialize ) {
+    rt.deserialize();
+    deserialized = true;
+  }
 
   if ( args.empty() ) {
     throw runtime_error( "not enough args" );
@@ -47,31 +53,31 @@ Handle parse_args( span_view<char*>& args, vector<ReadOnlyFile>& open_files )
   if ( str.starts_with( "file:" ) ) {
     std::filesystem::path file( string( str.substr( 5 ) ) );
     args.remove_prefix( 1 );
-    return runtime.add_blob( OwnedBlob::from_file( file ) );
+    return storage.add_blob( OwnedBlob::from_file( file ) );
   }
 
   if ( str.starts_with( "compile:" ) ) {
     std::filesystem::path file( string( str.substr( 8 ) ) );
     args.remove_prefix( 1 );
     if ( !deserialized ) {
-      runtime.deserialize();
+      rt.deserialize();
       deserialized = true;
     }
     OwnedMutTree compile_tree = OwnedMutTree::allocate( 3 );
     compile_tree.at( 0 ) = Handle( "unused" );
     compile_tree.at( 1 ) = COMPILE_ENCODE;
-    Handle blob = runtime.add_blob( OwnedBlob::from_file( file ) );
+    Handle blob = storage.add_blob( OwnedBlob::from_file( file ) );
     compile_tree.at( 2 ) = blob;
-    return runtime.add_tree( std::move( compile_tree ) ).as_thunk();
+    return storage.add_tree( std::move( compile_tree ) ).as_thunk();
   }
 
   if ( str.starts_with( "ref:" ) ) {
     if ( !deserialized ) {
-      runtime.deserialize();
+      rt.deserialize();
       deserialized = true;
     }
     args.remove_prefix( 1 );
-    auto ref = runtime.get_ref( str.substr( 4 ) );
+    auto ref = storage.get_ref( str.substr( 4 ) );
     if ( ref ) {
       return *ref;
     } else {
@@ -81,7 +87,7 @@ Handle parse_args( span_view<char*>& args, vector<ReadOnlyFile>& open_files )
 
   if ( str.starts_with( "name:" ) ) {
     if ( !deserialized ) {
-      runtime.deserialize();
+      rt.deserialize();
       deserialized = true;
     }
     args.remove_prefix( 1 );
@@ -124,7 +130,7 @@ Handle parse_args( span_view<char*>& args, vector<ReadOnlyFile>& open_files )
     for ( uint32_t i = 0; i < tree_size; ++i ) {
       the_tree[i] = parse_args( args, open_files );
     }
-    return runtime.add_tree( std::move( the_tree ) );
+    return storage.add_tree( std::move( the_tree ) );
   }
 
   if ( str.starts_with( "thunk:" ) ) {
@@ -169,7 +175,7 @@ T from_int( const std::span<const char> str )
   return ret;
 }
 
-ostream& operator<<( ostream& stream, const pretty_print& pp )
+ostream& operator<<( ostream& stream, const deep_pretty_print& pp )
 {
   auto& runtime = Runtime::get_instance().storage();
   const bool terminal
@@ -216,7 +222,7 @@ ostream& operator<<( ostream& stream, const pretty_print& pp )
       for ( unsigned int j = 0; j < pp.level + 1; ++j ) {
         stream << "  ";
       }
-      stream << to_string( i ) << ". " << pretty_print( view[i], pp.level + 1 );
+      stream << to_string( i ) << ". " << deep_pretty_print( view[i], pp.level + 1 );
     }
   } else if ( pp.name.is_thunk() ) {
     Handle encode_name = pp.name.as_tree();
@@ -224,7 +230,7 @@ ostream& operator<<( ostream& stream, const pretty_print& pp )
     for ( unsigned int i = 0; i < pp.level + 1; ++i ) {
       stream << "  ";
     }
-    stream << pretty_print( encode_name, pp.level + 1 );
+    stream << deep_pretty_print( encode_name, pp.level + 1 );
   } else if ( pp.name.is_tag() ) {
     const auto view = runtime.get_tree( pp.name );
     stream << ( terminal ? "\033[1;32mTag\033[m" : "Tag" ) << " (" << dec << view.size() << " entr"
@@ -233,7 +239,70 @@ ostream& operator<<( ostream& stream, const pretty_print& pp )
       for ( unsigned int j = 0; j < pp.level + 1; ++j ) {
         stream << "  ";
       }
-      stream << to_string( i ) << ". " << pretty_print( view[i], pp.level + 1 );
+      stream << to_string( i ) << ". " << deep_pretty_print( view[i], pp.level + 1 );
+    }
+  } else {
+    throw runtime_error( "can't pretty-print object" );
+  }
+  return stream;
+}
+
+ostream& operator<<( ostream& stream, const pretty_print& pp )
+{
+  auto& runtime = Runtime::get_instance().storage();
+  const bool terminal
+    = ( &stream == &cout and isatty( STDOUT_FILENO ) ) or ( &stream == &cerr and isatty( STDERR_FILENO ) );
+  if ( pp.name.is_blob() ) {
+    const auto view = runtime.get_blob( pp.name );
+    stream << ( terminal ? "\033[1;34mBlob\033[m" : "Blob" ) << " (" << dec << view.size() << " byte"
+           << ( view.size() != 1 ? "s" : "" ) << "): \"";
+    for ( const unsigned char ch : view.size() < 32 ? view : view.subspan( 0, 32 ) ) {
+      if ( ch == '\\' ) {
+        stream << "\\\\";
+      } else if ( isprint( ch ) ) {
+        stream << ch;
+      } else {
+        stream << "\\x" << hex << setw( 2 ) << setfill( '0' ) << static_cast<unsigned int>( ch );
+      }
+    }
+    if ( view.size() > 32 ) {
+      stream << ( terminal ? "\033[2;3m[\xe2\x80\xa6]\033[m" : "[...]" );
+    }
+    stream << "\"";
+
+    switch ( view.size() ) {
+      case sizeof( uint8_t ):
+        stream << " (uint8:" << dec << setw( 0 ) << static_cast<unsigned int>( from_int<uint8_t>( view ) ) << ")";
+        break;
+      case sizeof( uint16_t ):
+        stream << " (uint16:" << dec << setw( 0 ) << from_int<uint16_t>( view ) << ")";
+        break;
+      case sizeof( uint32_t ):
+        stream << " (uint32:" << dec << setw( 0 ) << from_int<uint32_t>( view ) << ")";
+        break;
+      case sizeof( uint64_t ):
+        stream << " (uint64:" << dec << setw( 0 ) << from_int<uint64_t>( view ) << ")";
+        break;
+    }
+
+    stream << "\n";
+  } else if ( pp.name.is_tree() ) {
+    const auto view = runtime.get_tree( pp.name );
+    stream << ( terminal ? "\033[1;32mTree\033[m" : "Tree" ) << " (" << dec << view.size() << " entr"
+           << ( view.size() != 1 ? "ies" : "y" ) << "):\n";
+    for ( unsigned int i = 0; i < view.size(); ++i ) {
+      stream << "  " << to_string( i ) << ". " << runtime.get_display_name( view[i] ) << endl;
+    }
+  } else if ( pp.name.is_thunk() ) {
+    Handle encode_name = pp.name.as_tree();
+    stream << ( terminal ? "\033[1;36mThunk\033[m" : "Thunk" ) << ":\n";
+    stream << runtime.get_display_name( encode_name );
+  } else if ( pp.name.is_tag() ) {
+    const auto view = runtime.get_tree( pp.name );
+    stream << ( terminal ? "\033[1;32mTag\033[m" : "Tag" ) << " (" << dec << view.size() << " entr"
+           << ( view.size() != 1 ? "ies" : "y" ) << "):\n";
+    for ( unsigned int i = 0; i < view.size(); ++i ) {
+      stream << "  " << to_string( i ) << ". " << runtime.get_display_name( view[i] ) << endl;
     }
   } else {
     throw runtime_error( "can't pretty-print object" );

--- a/src/tester/tester-utils.cc
+++ b/src/tester/tester-utils.cc
@@ -49,7 +49,7 @@ Handle get_full_name( string_view short_name )
         throw std::runtime_error( "Object exists but it is not a Blob." );
       }
 
-      if ( ( prefix == 'T' or prefix == 'K' ) and !full.is_tree() ) {
+      if ( ( prefix == 'E' or prefix == 'K' ) and !full.is_tree() ) {
         throw std::runtime_error( "Object exists but it is not a Tree/Thunk." );
       }
 

--- a/src/tester/tester-utils.hh
+++ b/src/tester/tester-utils.hh
@@ -26,7 +26,25 @@ struct pretty_print
   {}
 };
 
+struct pretty_print_relation
+{
+  Relation relation;
+  pretty_print_relation( Relation relation )
+    : relation( relation )
+  {}
+};
+
+struct pretty_print_handle
+{
+  Handle handle;
+  pretty_print_handle( Handle handle )
+    : handle( handle )
+  {}
+};
+
 std::ostream& operator<<( std::ostream& stream, const deep_pretty_print& pp );
 std::ostream& operator<<( std::ostream& stream, const pretty_print& pp );
+std::ostream& operator<<( std::ostream& stream, const pretty_print_relation& pp );
+std::ostream& operator<<( std::ostream& stream, const pretty_print_handle& pp );
 
 Handle parse_args( span_view<char*>& args, std::vector<ReadOnlyFile>& open_files, bool deserialize = false );

--- a/src/tester/tester-utils.hh
+++ b/src/tester/tester-utils.hh
@@ -8,16 +8,25 @@
 
 #define COMPILE_ENCODE *Runtime::get_instance().storage().get_ref( "compile-encode" )
 
-struct pretty_print
+struct deep_pretty_print
 {
   Handle name;
   unsigned int level;
-  pretty_print( Handle name, unsigned int level = 0 )
+  deep_pretty_print( Handle name, unsigned int level = 0 )
     : name( name )
     , level( level )
   {}
 };
 
+struct pretty_print
+{
+  Handle name;
+  pretty_print( Handle name )
+    : name( name )
+  {}
+};
+
+std::ostream& operator<<( std::ostream& stream, const deep_pretty_print& pp );
 std::ostream& operator<<( std::ostream& stream, const pretty_print& pp );
 
-Handle parse_args( span_view<char*>& args, std::vector<ReadOnlyFile>& open_files );
+Handle parse_args( span_view<char*>& args, std::vector<ReadOnlyFile>& open_files, bool deserialize = false );

--- a/src/util/util.hh
+++ b/src/util/util.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <type_traits>
+
+template<typename T>
+constexpr auto to_underlying( T t ) noexcept
+{
+  return static_cast<std::underlying_type_t<T>>( t );
+}

--- a/testing/wasm-examples/CMakeLists.txt
+++ b/testing/wasm-examples/CMakeLists.txt
@@ -9,14 +9,14 @@ add_custom_command(
 add_custom_target(addblob-wasm ALL DEPENDS addblob.wasm)
 
 add_custom_command(
-  OUTPUT "addblob-trace.wasm"
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/addblob-trace.wat
+  OUTPUT "addblob-pin.wasm"
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/addblob-pin.wat
   COMMAND $ENV{HOME}/wasm-toolchain/wabt/build/wat2wasm
           --enable-multi-memory
-          ${CMAKE_CURRENT_SOURCE_DIR}/addblob-trace.wat
-          -o addblob-trace.wasm)
+          ${CMAKE_CURRENT_SOURCE_DIR}/addblob-pin.wat
+          -o addblob-pin.wasm)
 
-add_custom_target(addblob-trace-wasm ALL DEPENDS addblob-trace.wasm)
+add_custom_target(addblob-pin-wasm ALL DEPENDS addblob-pin.wasm)
 
 add_custom_command(
   OUTPUT "add-simple.wasm"

--- a/testing/wasm-examples/CMakeLists.txt
+++ b/testing/wasm-examples/CMakeLists.txt
@@ -6,7 +6,15 @@ add_custom_command(
           ${CMAKE_CURRENT_SOURCE_DIR}/addblob.wat
           -o addblob.wasm)
 
-add_custom_target(addblob_wasm ALL DEPENDS addblob.wasm)
+add_custom_command(
+  OUTPUT "addblob-trace.wasm"
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/addblob-trace.wat
+  COMMAND $ENV{HOME}/wasm-toolchain/wabt/build/wat2wasm
+          --enable-multi-memory
+          ${CMAKE_CURRENT_SOURCE_DIR}/addblob-trace.wat
+          -o addblob-trace.wasm)
+
+add_custom_target(addblob-trace-wasm ALL DEPENDS addblob-trace.wasm)
 
 add_custom_command(
   OUTPUT "add-simple.wasm"

--- a/testing/wasm-examples/CMakeLists.txt
+++ b/testing/wasm-examples/CMakeLists.txt
@@ -6,6 +6,8 @@ add_custom_command(
           ${CMAKE_CURRENT_SOURCE_DIR}/addblob.wat
           -o addblob.wasm)
 
+add_custom_target(addblob-wasm ALL DEPENDS addblob.wasm)
+
 add_custom_command(
   OUTPUT "addblob-trace.wasm"
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/addblob-trace.wat

--- a/testing/wasm-examples/addblob-pin.wat
+++ b/testing/wasm-examples/addblob-pin.wat
@@ -6,7 +6,7 @@
   (import "fixpoint" "create_blob_rw_mem_1" (func $create_blob_rw_mem_1 (param i32) (result externref)))
   (import "fixpoint" "create_tree_rw_table_0" (func $create_tree_rw_table_0 (param i32) (result externref)))
   (import "fixpoint" "create_tag" (func $create_tag (param externref externref) (result externref)))
-  (import "fixpoint" "trace" (func $trace (param externref externref) (result i32)))
+  (import "fixpoint" "pin" (func $pin (param externref externref) (result i32)))
   (memory $ro_mem_0 (export "ro_mem_0") 0)
   (memory $ro_mem_1 (export "ro_mem_1") 0)
   (memory $rw_mem_0 (export "rw_mem_0") 1)
@@ -34,7 +34,7 @@
 
     (local.get $result)
     (call $create_tag (local.get $result) (local.get $infotree))
-    call $trace
+    call $pin
     drop
 
     (local.get $result)

--- a/testing/wasm-examples/addblob-trace.wat
+++ b/testing/wasm-examples/addblob-trace.wat
@@ -1,0 +1,42 @@
+(module
+  (import "fixpoint" "attach_tree_ro_table_0" (func $attach_tree_ro_tree_0 (param externref)))
+  (import "fixpoint" "attach_blob_ro_mem_0" (func $attach_blob_ro_mem_0 (param externref)))
+  (import "fixpoint" "attach_blob_ro_mem_1" (func $attach_blob_ro_mem_1 (param externref)))
+  (import "fixpoint" "create_blob_rw_mem_0" (func $create_blob_rw_mem_0 (param i32) (result externref)))
+  (import "fixpoint" "create_blob_rw_mem_1" (func $create_blob_rw_mem_1 (param i32) (result externref)))
+  (import "fixpoint" "create_tree_rw_table_0" (func $create_tree_rw_table_0 (param i32) (result externref)))
+  (import "fixpoint" "create_tag" (func $create_tag (param externref externref) (result externref)))
+  (import "fixpoint" "trace" (func $trace (param externref externref) (result i32)))
+  (memory $ro_mem_0 (export "ro_mem_0") 0)
+  (memory $ro_mem_1 (export "ro_mem_1") 0)
+  (memory $rw_mem_0 (export "rw_mem_0") 1)
+  (memory (export "rw_mem_1") (data "+"))
+  (table $ro_table (export "ro_table_0") 0 externref)
+  (table $rw_table_0 (export "rw_table_0") 3 externref)
+  (func (export "_fixpoint_apply")
+    (param $encode externref)
+    (result externref)
+    (local $result externref)
+    (local $infotree externref)
+    (call $attach_tree_ro_tree_0 (local.get $encode))
+    (call $attach_blob_ro_mem_0 (table.get $ro_table (i32.const 2))) 
+    (call $attach_blob_ro_mem_1 (table.get $ro_table (i32.const 3)))
+    i32.const 0
+    (i32.add (i32.load 0 (i32.const 0)) (i32.load 1 (i32.const 0)))
+    i32.store $rw_mem_0
+    (local.set $result (call $create_blob_rw_mem_0 (i32.const 4)))
+
+    ;; Create tracing info
+    (table.set $rw_table_0 (i32.const 0) (table.get $ro_table (i32.const 2)))
+    (table.set $rw_table_0 (i32.const 1) (call $create_blob_rw_mem_1 (i32.const 1)))
+    (table.set $rw_table_0 (i32.const 2) (table.get $ro_table (i32.const 3)))
+    (local.set $infotree (call $create_tree_rw_table_0 (i32.const 3)))
+
+    (local.get $result)
+    (call $create_tag (local.get $result) (local.get $infotree))
+    call $trace
+    drop
+
+    (local.get $result)
+  )
+)


### PR DESCRIPTION
This PR implements relations for non-distributed workloads

* There are 2 different "explicit" relations: `Eval`, `Apply` generated by actual `eval` and `apply`.
* Serializing a `Eval` or `Apply` relation serializes the lhs and rhs objects of the relation and the relation itself, and any relation the relation depends on.
* Serializing an object serializes the object itself (including any recursively fully accessible objects), the relation itself and any object the object "pins".
* The `rw-tester` serializes the `Eval` relation of the input Thunk.

This PR also implements a `fix` that interacts with `.fix` but does not do any real work. `fix` currently has following commands:
* `what`:  print the handle to the object
* `content`: print content of an object
* `deep-content`: print content of an object recursively
* `result-apply` and `result-eval`: print the result of eval/apply(object)
* `steps-eval`: print all dependencies of an eval-relation
* `step-eval`: print immediate dependencies of an eval-relation
* `explain`: print all relations point to the object + all tags that tag the object + all objects this object pin

In addition, this PR adds a `short-name` arg to tester command line args. The 7 bytes in the pretty-print of a Handle can be passed in and expanded to the full handle
