### PR TITLE
Switching from PicoSHA2 to BLAKE3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "third-party/abseil-cpp"]
 	path = third-party/abseil-cpp
 	url = https://github.com/abseil/abseil-cpp
+[submodule "third-party/BLAKE3"]
+	path = third-party/BLAKE3
+	url = https://github.com/BLAKE3-team/BLAKE3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "files.associations": {
+        "array": "cpp",
+        "bitset": "cpp",
+        "string_view": "cpp",
+        "initializer_list": "cpp",
+        "span": "cpp",
+        "regex": "cpp",
+        "utility": "cpp",
+        "valarray": "cpp"
+    },
+    "C_Cpp.errorSquiggles": "disabled"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ set(ABSL_PROPAGATE_CXX_STD on)
 add_subdirectory(${PROJECT_SOURCE_DIR}/third-party/abseil-cpp)
 include_directories(SYSTEM "${PROJECT_SOURCE_DIR}/third-party/abseil-cpp")
 
+add_subdirectory(${PROJECT_SOURCE_DIR}/third-party/BLAKE3/c)
+include_directories(SYSTEM "${PROJECT_SOURCE_DIR}/third-party/BLAKE3/c")
+
 include(ExternalProject)
 ExternalProject_Add(applications
   SOURCE_DIR "${PROJECT_SOURCE_DIR}/applications"

--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -6,6 +6,7 @@ add_custom_target (fixpoint-check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-fai
 add_custom_target (all-check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R "^t_" COMMENT "Testing...")
 
 add_test(NAME t_add WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-add)
+add_test(NAME t_blake3 WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-blake3)
 add_test(NAME t_fib WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-fib)
 add_test(NAME t_trap WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/test-trap.sh)
 add_test(NAME t_map WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-map)

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -11,4 +11,4 @@ add_custom_command(
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_library (runtime STATIC ${LIB_SOURCES} wasm-rt-content.h)
-target_link_libraries(runtime PUBLIC component util glog PRIVATE wasmrt absl::flat_hash_map)
+target_link_libraries(runtime PUBLIC component util glog PRIVATE wasmrt absl::flat_hash_map blake3)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(test-add test-add.cc main.cc)
 target_link_libraries(test-add runtime)
 
+add_executable(test-blake3 test-blake3.cc main.cc)
+target_link_libraries(test-blake3 util glog)
+
 add_executable(test-fib test-fib.cc main.cc)
 target_link_libraries(test-fib runtime)
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(test-add test-add.cc main.cc)
 target_link_libraries(test-add runtime)
 
-add_executable(test-blake3 test-blake3.cc main.cc)
-target_link_libraries(test-blake3 util glog)
+# add_executable(test-blake3 test-blake3.cc main.cc)
+# target_link_libraries(test-blake3 util glog)
 
 add_executable(test-fib test-fib.cc main.cc)
 target_link_libraries(test-fib runtime)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(test-add test-add.cc main.cc)
 target_link_libraries(test-add runtime)
 
-# add_executable(test-blake3 test-blake3.cc main.cc)
-# target_link_libraries(test-blake3 util glog)
+add_executable(test-blake3 test-blake3.cc main.cc)
+target_link_libraries(test-blake3 util glog)
 
 add_executable(test-fib test-fib.cc main.cc)
 target_link_libraries(test-fib runtime)

--- a/src/tests/test-blake3.cc
+++ b/src/tests/test-blake3.cc
@@ -1,0 +1,35 @@
+#include "base16.hh"
+#include "blake3.hh"
+#include "test.hh"
+#include <stdio.h>
+
+using namespace std;
+
+void test( void )
+{
+
+  // "hello world" test
+  string_view test1_s1 = "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24";
+  string_view test1_s2 = "hello world";
+  string result = blake3::encode( (const string_view)test1_s2 );
+  __m256i str;
+  CHECK_EQ( result.size(), sizeof( str ) );
+  memcpy( &str, result.data(), result.size() );
+  CHECK_EQ( base16::encode( str ), test1_s1 );
+
+  // empty string test
+  string_view test2_s1 = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
+  string_view test2_s2 = "";
+  result = blake3::encode( (const string_view)test2_s2 );
+  CHECK_EQ( result.size(), sizeof( str ) );
+  memcpy( &str, result.data(), result.size() );
+  CHECK_EQ( base16::encode( str ), test2_s1 );
+
+  // extremely long string test
+  string_view test3_s1 = "711d65565a7d0c3618758f9fefa1b1a2bb9ba60fc3ed4f468a7c2f7c9878004d";
+  string_view test3_s2 = "When forty winters shall beseige thy brow,And dig deep trenches in thy beauty's  ";
+  result = blake3::encode( (const string_view)test3_s2 );
+  CHECK_EQ( result.size(), sizeof( str ) );
+  memcpy( &str, result.data(), result.size() );
+  CHECK_EQ( base16::encode( str ), test3_s1 );
+}

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,2 +1,3 @@
 file (GLOB LIB_SOURCES "*.cc")
 add_library (util STATIC ${LIB_SOURCES})
+target_link_libraries(util PUBLIC blake3)

--- a/src/util/blake3.cc
+++ b/src/util/blake3.cc
@@ -1,0 +1,32 @@
+#include "sha256.hh"
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Weffc++"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+#include "blake3.h"
+#include "timer.hh"
+
+using namespace std;
+
+namespace blake3 {
+std::string hash( const std::string& input )
+{
+  blake3_hasher hasher;
+  blake3_hasher_init( &hasher );
+
+  blake3_hasher_update( &hasher, input.data(), input.size() );
+
+  uint8_t hash_buf[BLAKE3_OUT_LEN];
+  blake3_hasher_finalize( &hasher, hash_buf, BLAKE3_OUT_LEN );
+
+  // Convert the hash to a hexadecimal string
+  std::stringstream ss;
+  ss << std::hex << std::setfill( '0' );
+  for ( size_t i = 0; i < BLAKE3_OUT_LEN; ++i ) {
+    ss << std::setw( 2 ) << static_cast<unsigned>( hash_buf[i] );
+  }
+
+  return ss.str();
+}
+
+}

--- a/src/util/blake3.cc
+++ b/src/util/blake3.cc
@@ -5,6 +5,7 @@
 #endif
 #include "blake3.h"
 #include "timer.hh"
+#include <cstring>
 
 using namespace std;
 
@@ -13,11 +14,9 @@ std::string encode( const std::string_view input )
 {
   blake3_hasher hasher;
   blake3_hasher_init( &hasher );
-
   blake3_hasher_update( &hasher, input.data(), input.size() );
-
-  uint8_t hash_buf[BLAKE3_OUT_LEN];
-  blake3_hasher_finalize( &hasher, hash_buf, BLAKE3_OUT_LEN );
-  return std::string( (char*)hash_buf, BLAKE3_OUT_LEN );
+  string digest( BLAKE3_OUT_LEN, '\0' );
+  blake3_hasher_finalize( &hasher, reinterpret_cast<uint8_t*>( digest.data() ), BLAKE3_OUT_LEN );
+  return digest;
 }
 }

--- a/src/util/blake3.cc
+++ b/src/util/blake3.cc
@@ -1,4 +1,4 @@
-#include "sha256.hh"
+#include "blake3.hh"
 #ifndef __clang__
 #pragma GCC diagnostic ignored "-Weffc++"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
@@ -9,7 +9,7 @@
 using namespace std;
 
 namespace blake3 {
-std::string hash( const std::string& input )
+std::string encode( const std::string_view input )
 {
   blake3_hasher hasher;
   blake3_hasher_init( &hasher );
@@ -18,15 +18,6 @@ std::string hash( const std::string& input )
 
   uint8_t hash_buf[BLAKE3_OUT_LEN];
   blake3_hasher_finalize( &hasher, hash_buf, BLAKE3_OUT_LEN );
-
-  // Convert the hash to a hexadecimal string
-  std::stringstream ss;
-  ss << std::hex << std::setfill( '0' );
-  for ( size_t i = 0; i < BLAKE3_OUT_LEN; ++i ) {
-    ss << std::setw( 2 ) << static_cast<unsigned>( hash_buf[i] );
-  }
-
-  return ss.str();
+  return std::string( (char*)hash_buf, BLAKE3_OUT_LEN );
 }
-
 }

--- a/src/util/blake3.hh
+++ b/src/util/blake3.hh
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <span>
+#include <string>
+
+namespace blake3 {
+
+std::string encode( const std::string_view input );
+
+template<class T>
+std::string encode_span( std::span<T> input ) requires( std::is_const_v<T> )
+{
+  return encode( { reinterpret_cast<const char* const>( input.data() ), input.size() * sizeof( T ) } );
+}
+
+bool verify( const std::string& ret, const std::string& input );
+}

--- a/src/util/sha256.cc
+++ b/src/util/sha256.cc
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Weffc++"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
-#include "blake3.h"
+#include "PicoSHA2/picosha2.h"
 #include "timer.hh"
 
 using namespace std;
@@ -11,21 +11,9 @@ using namespace std;
 namespace sha256 {
 string encode( std::string_view input )
 {
-    blake3_hasher hasher;
-    blake3_hasher_init(&hasher);
-    uint length = input.length();
-
-    char digest[2 * BLAKE3_OUT_LEN + 1];
-    uint8_t hash_buf[BLAKE3_OUT_LEN];
-
-    blake3_hasher_update(&hasher, input.data(), length);
-    blake3_hasher_finalize(&hasher, hash_buf, BLAKE3_OUT_LEN);
-
-    // Convert the hash buffer hexadecimal to a string
-    for (size_t i = 0; i < BLAKE3_OUT_LEN; i++) {
-	    sprintf(&digest[i * 2],"%02x", hash_buf[i]);
-    }
-    digest[2 * BLAKE3_OUT_LEN] = '\0';
-    return digest;
+  GlobalScopeTimer<Timer::Category::Hash> record_timer;
+  string digest( picosha2::k_digest_size, 0 );
+  picosha2::hash256( input, digest );
+  return digest;
 }
 }

--- a/src/util/sha256.cc
+++ b/src/util/sha256.cc
@@ -3,7 +3,7 @@
 #pragma GCC diagnostic ignored "-Weffc++"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
-#include "PicoSHA2/picosha2.h"
+#include "blake3.h"
 #include "timer.hh"
 
 using namespace std;
@@ -11,9 +11,21 @@ using namespace std;
 namespace sha256 {
 string encode( std::string_view input )
 {
-  GlobalScopeTimer<Timer::Category::Hash> record_timer;
-  string digest( picosha2::k_digest_size, 0 );
-  picosha2::hash256( input, digest );
-  return digest;
+    blake3_hasher hasher;
+    blake3_hasher_init(&hasher);
+    uint length = input.length();
+
+    char digest[2 * BLAKE3_OUT_LEN + 1];
+    uint8_t hash_buf[BLAKE3_OUT_LEN];
+
+    blake3_hasher_update(&hasher, input.data(), length);
+    blake3_hasher_finalize(&hasher, hash_buf, BLAKE3_OUT_LEN);
+
+    // Convert the hash buffer hexadecimal to a string
+    for (size_t i = 0; i < BLAKE3_OUT_LEN; i++) {
+	    sprintf(&digest[i * 2],"%02x", hash_buf[i]);
+    }
+    digest[2 * BLAKE3_OUT_LEN] = '\0';
+    return digest;
 }
 }


### PR DESCRIPTION
This is a draft PR for switching to BLAKE3 as the hashing algorithm.
Here are the tasks I need to complete in order to do this:
- [x] Added BLAKE3 submodule
- [x] Ensure BLAKE3 is compiling
- [ ] Switch over call sites from PicoSHA2 to BLAKE3
- [ ] Remove all PicoSHA2 references in the Fix codebase

Update 1/16/24:
- I am not switching over the call sites from PicoSHA256 to BLAKE3 in runtimestorage.cc for now. I added blake3.cc and blake3.hh along with three unit tests for blake3. 
- In the testing file with the run executables, I commented out the blake3 test calls
`add_executable(test-blake3 test-blake3.cc main.cc)`
`target_link_libraries(test-blake3 util glog)`