### PR TITLE
Handle "name:" and "label:" from command line arguments as identification Thunks

### DIFF
--- a/src/runtime/executor.cc
+++ b/src/runtime/executor.cc
@@ -124,10 +124,11 @@ Result<Value> Executor::load( Handle<Value> value )
         return x;
 
       return get_or_delegate( x ).and_then( [&]( auto t ) -> Result<Value> {
-        bool all_loaded = false;
+        bool all_loaded = true;
         for ( const auto& handle : t->span() ) {
           all_loaded
-            &= handle::extract<Value>( handle ).and_then( [&]( auto h ) { return load( h ); } ).has_value();
+            = all_loaded
+              && handle::extract<Value>( handle ).and_then( [&]( auto h ) { return load( h ); } ).has_value();
         }
         if ( all_loaded ) {
           return x;

--- a/src/runtime/executor.cc
+++ b/src/runtime/executor.cc
@@ -50,6 +50,13 @@ void Executor::run()
 
 void Executor::progress( Handle<Relation> relation )
 {
+  {
+    auto parent = parent_.lock();
+    if ( parent && parent->contains( relation ) ) {
+      return;
+    }
+  }
+
   auto result = evaluator_.relate( relation );
   if ( !result ) {
     todo_ << relation;
@@ -61,6 +68,7 @@ std::optional<BlobData> Executor::get_or_delegate( Handle<Named> goal )
   if ( storage_.contains( goal ) ) {
     return storage_.get( goal );
   }
+
   auto parent = parent_.lock();
   if ( parent ) {
     return parent->get( goal );
@@ -75,6 +83,7 @@ std::optional<TreeData> Executor::get_or_delegate( Handle<AnyTree> goal )
   if ( storage_.contains( goal ) ) {
     return storage_.get( goal );
   }
+
   auto parent = parent_.lock();
   if ( parent ) {
     return parent->get( goal );
@@ -104,9 +113,29 @@ Result<Value> Executor::load( Handle<Value> value )
     [&]( Handle<Blob> x ) -> Result<Blob> {
       if ( x.contains<Literal>() )
         return x;
+
+      if ( storage_.contains( x.unwrap<Named>() ) )
+        return x;
+
       return get_or_delegate( x.unwrap<Named>() ).transform( [&]( auto ) { return x; } );
     },
-    [&]( Handle<ValueTree> x ) { return get_or_delegate( x ).transform( [&]( auto ) { return x; } ); },
+    [&]( Handle<ValueTree> x ) -> Result<Value> {
+      if ( storage_.contains( x ) )
+        return x;
+
+      return get_or_delegate( x ).and_then( [&]( auto t ) -> Result<Value> {
+        bool all_loaded = false;
+        for ( const auto& handle : t->span() ) {
+          all_loaded
+            &= handle::extract<Value>( handle ).and_then( [&]( auto h ) { return load( h ); } ).has_value();
+        }
+        if ( all_loaded ) {
+          return x;
+        } else {
+          return {};
+        }
+      } );
+    },
     [&]( auto x ) { return x; },
   } );
 }
@@ -118,6 +147,24 @@ Result<Object> Executor::apply( Handle<ObjectTree> combination )
 
   if ( storage_.contains( goal ) ) {
     return storage_.get( goal );
+  } else {
+    auto parent = parent_.lock();
+    if ( parent && parent->contains( goal ) ) {
+      VLOG( 2 ) << "Relation existed " << goal;
+      auto res = parent->get( goal );
+
+      handle::data( res.value() )
+        .visit<void>( overload {
+          [&]( Handle<Named> n ) { load( n ); },
+          [&]( Handle<ValueTree> t ) { load( t ); },
+          [&]( Handle<ObjectTree> ) { throw std::runtime_error( "unimplemented" ); },
+          [&]( Handle<ExpressionTree> ) { throw std::runtime_error( "unimplemented" ); },
+          [&]( Handle<Literal> ) {},
+          [&]( Handle<Relation> ) {},
+        } );
+
+      return res;
+    }
   }
 
   TreeData tree;
@@ -130,15 +177,15 @@ Result<Object> Executor::apply( Handle<ObjectTree> combination )
   }
   tree = storage_.get( combination );
 
-  // Load minrepo to memory
-  load_minrepo( combination );
-
   auto result = runner_->apply( combination, tree );
 
   storage_.create( goal, result );
-  auto parent = parent_.lock();
-  if ( parent )
-    parent->put( goal, result );
+
+  {
+    auto parent = parent_.lock();
+    if ( parent )
+      parent->put( goal, result );
+  }
 
   auto live = live_.write();
   live->erase( goal );
@@ -148,11 +195,24 @@ Result<Object> Executor::apply( Handle<ObjectTree> combination )
 Result<Value> Executor::evalStrict( Handle<Object> expression )
 {
   Handle<Eval> goal( expression );
-  {
-    if ( storage_.contains( goal ) ) {
-      return storage_.get_relation( goal );
+
+  if ( storage_.contains( goal ) ) {
+    return storage_.get( goal ).unwrap<Value>();
+  } else {
+    auto parent = parent_.lock();
+    if ( parent && parent->contains( goal ) ) {
+      VLOG( 2 ) << "Relation existed " << goal;
+      auto res = parent->get( goal )->unwrap<Value>();
+      res.visit<void>( overload {
+        [&]( Handle<Blob> n ) { load( n ); },
+        [&]( Handle<ValueTree> t ) { load( t ); },
+        []( auto ) {},
+      } );
+
+      return res;
     }
   }
+
   auto result = evaluator_.evalStrict( expression );
   if ( !result )
     return {};

--- a/src/runtime/executor.hh
+++ b/src/runtime/executor.hh
@@ -35,9 +35,15 @@ public:
 
   Handle<Value> execute( Handle<Relation> x )
   {
-    if ( storage_.contains( x ) ) {
-      return storage_.get( x ).unwrap<Value>();
+    {
+      auto parent = parent_.lock();
+      if ( parent && parent->contains( x ) ) {
+        VLOG( 2 ) << "Relation existed " << x;
+        return parent->get( x )->unwrap<Value>();
+      }
     }
+
+    VLOG( 1 ) << "Relation does not exit " << x.content;
     todo_ << x;
     Handle<Object> current = storage_.wait( x );
     while ( not current.contains<Value>() ) {

--- a/src/runtime/runtimes.cc
+++ b/src/runtime/runtimes.cc
@@ -106,6 +106,10 @@ Handle<Value> ReadOnlyRT::execute( Handle<Relation> x )
 
 Handle<Value> ReadWriteRT::execute( Handle<Relation> x )
 {
+  if ( contains( x ) ) {
+    return get( x ).value().unwrap<Value>();
+  }
+
   auto res = executor_->execute( x );
 
   executor_->visit( x, [this]( Handle<AnyDataType> h ) {

--- a/src/storage/repository.cc
+++ b/src/storage/repository.cc
@@ -232,7 +232,7 @@ bool Repository::contains( Handle<AnyTree> handle )
 bool Repository::contains( Handle<Relation> handle )
 {
   try {
-    return fs::exists( repo_ / "relations" / base16::encode( handle.content ) );
+    return fs::is_symlink( repo_ / "relations" / base16::encode( Handle<Fix>( handle ).content ) );
   } catch ( fs::filesystem_error& ) {
     throw RepositoryCorrupt( repo_ );
   }


### PR DESCRIPTION
* `name:` and `label:` are parsed as Identification Thunk and `parse_args` creates a `Handle<Strict>` to the Identification Thunk if it is consumed by another Thunk.
* `load()` loads `ValueTree` recursively.
* `apply` and `evalStrict` checks whether the Relation already exists and loads the result before doing real work.