### PR TITLE
Add dependency graph and task deduplication

### DIFF
--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -16,6 +16,7 @@ add_test(NAME u_evaluator COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-eva
 add_test(NAME u_executor COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-executor)
 add_test(NAME u_distributed COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-distributed)
 add_test(NAME u_blake3 WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-blake3)
+add_test(NAME u_dependency_graph COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-dependency-graph)
 
 add_test(NAME t_add COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-add)
 add_test(NAME t_fib COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-fib)

--- a/src/runtime/dependency_graph.hh
+++ b/src/runtime/dependency_graph.hh
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <glog/logging.h>
+
+#include "handle.hh"
+
+/**
+ * Serves the purpose of a "blocked queue" in a conventional OS; since we know computations are deterministic, we
+ * instead use a directed graph to deduplicate redundant work.
+ *
+ * This class is not thread-safe, and should be protected by a mutex.
+ */
+class DependencyGraph
+{
+public:
+  using Task = Handle<Relation>;
+  using Result = Handle<Object>;
+
+private:
+  absl::flat_hash_set<Task> running_ {};
+  absl::flat_hash_map<Task, absl::flat_hash_set<Task>> forward_dependencies_ {};
+  absl::flat_hash_map<Task, absl::flat_hash_set<Task>> backward_dependencies_ {};
+
+public:
+  DependencyGraph() {}
+
+  bool contains( Task task ) const { return running_.contains( task ); }
+
+  /**
+   * Marks a Task as started.  Returns whether the Task is new.
+   *
+   * @p task  The Task to mark as started.
+   * @return  If the Task should actually be started (i.e., if the Task is new).
+   */
+  bool start( Task task )
+  {
+    VLOG( 1 ) << "starting " << task;
+    if ( contains( task ) )
+      return false;
+    running_.insert( task );
+    return true;
+  }
+
+  /**
+   * Marks a Task as depending upon another.  Returns whether the dependee is new.
+   *
+   * @p blocked   The Task to mark as blocked on @p runnable.
+   * @p runnable  The Task to mark as runnable, blocking @p blocked.
+   * @return      If the @p runnable should actually be started.
+   */
+  bool add_dependency( Task blocked, Task runnable )
+  {
+    VLOG( 1 ) << "adding dependency from " << blocked << " to " << runnable;
+    forward_dependencies_[blocked].insert( runnable );
+    backward_dependencies_[runnable].insert( blocked );
+    return start( runnable );
+  }
+
+  /**
+   * Marks a Task as complete, and determines which other Tasks are now ready to be run.
+   *
+   * @p[in]   task        The Task to mark as complete.
+   * @p[out]  unblocked   The set of Tasks which can now be started.
+   */
+  void finish( Task task, absl::flat_hash_set<Task>& unblocked )
+  {
+    VLOG( 1 ) << "finished " << task;
+    running_.erase( task );
+    if ( backward_dependencies_.contains( task ) ) {
+      for ( const auto dependent : backward_dependencies_[task] ) {
+        auto& target = forward_dependencies_[dependent];
+        target.erase( task );
+        if ( target.empty() ) {
+          VLOG( 2 ) << "resuming " << dependent;
+          unblocked.insert( dependent );
+          forward_dependencies_.erase( dependent );
+        }
+      }
+      backward_dependencies_.erase( task );
+    }
+  }
+};

--- a/src/runtime/executor.cc
+++ b/src/runtime/executor.cc
@@ -13,6 +13,8 @@ using Result = Executor::Result<T>;
 
 using namespace std;
 
+thread_local static std::optional<Handle<Relation>> current_ {};
+
 Executor::Executor( size_t threads, weak_ptr<IRuntime> parent, optional<shared_ptr<Runner>> runner )
   : evaluator_( *this )
   , parent_( parent )
@@ -21,6 +23,7 @@ Executor::Executor( size_t threads, weak_ptr<IRuntime> parent, optional<shared_p
 {
   for ( size_t i = 0; i < threads; i++ ) {
     threads_.emplace_back( [&]() {
+      current_ = {};
       fixpoint::storage = &storage_;
       run();
     } );
@@ -57,7 +60,9 @@ void Executor::progress( Handle<Relation> relation )
     }
   }
 
+  current_ = relation;
   auto result = evaluator_.relate( relation );
+  current_ = {};
   if ( !result ) {
     todo_ << relation;
   }
@@ -93,18 +98,21 @@ std::optional<TreeData> Executor::get_or_delegate( Handle<AnyTree> goal )
   }
 }
 
-Result<Object> Executor::get_or_delegate( Handle<Relation> goal )
+Result<Object> Executor::get_or_delegate( Handle<Relation> goal, Handle<Relation> blocked )
 {
   if ( storage_.contains( goal ) ) {
     return storage_.get( goal );
   }
   auto parent = parent_.lock();
   if ( parent ) {
-    return parent->get( goal );
-  } else {
-    todo_ << goal;
-    return {};
+    auto result = parent->get( goal );
+    if ( result ) {
+      return result;
+    }
   }
+  auto graph = graph_.write();
+  graph->add_dependency( goal, blocked );
+  return {};
 }
 
 Result<Value> Executor::load( Handle<Value> value )
@@ -168,28 +176,15 @@ Result<Object> Executor::apply( Handle<ObjectTree> combination )
     }
   }
 
-  TreeData tree;
-  {
-    auto live = live_.write();
-    if ( live->contains( goal ) ) {
-      return {};
-    }
-    live->insert( goal );
-  }
-  tree = storage_.get( combination );
+  TreeData tree = storage_.get( combination );
 
   auto result = runner_->apply( combination, tree );
 
-  storage_.create( goal, result );
+  put( goal, result );
+  auto parent = parent_.lock();
+  if ( parent )
+    parent->put( goal, result );
 
-  {
-    auto parent = parent_.lock();
-    if ( parent )
-      parent->put( goal, result );
-  }
-
-  auto live = live_.write();
-  live->erase( goal );
   return result;
 }
 
@@ -218,7 +213,7 @@ Result<Value> Executor::evalStrict( Handle<Object> expression )
   if ( !result )
     return {};
 
-  storage_.create( goal, *result );
+  put( goal, *result );
   auto parent = parent_.lock();
   if ( parent )
     parent->put( goal, *result );
@@ -233,34 +228,32 @@ Result<Object> Executor::evalShallow( Handle<Object> expression )
 
 Result<ValueTree> Executor::mapEval( Handle<ObjectTree> tree )
 {
-  {
-    bool ready = true;
-    auto data = storage_.get( tree );
-    for ( const auto& x : data->span() ) {
-      auto obj = x.unwrap<Expression>().unwrap<Object>();
-      Handle<Eval> eval( obj );
-      auto result = get_or_delegate( eval ); // this will start the relevant eval if it's not ready
-      if ( not result ) {
-        ready = false;
-      }
+  bool ready = true;
+  auto data = storage_.get( tree );
+  for ( const auto& x : data->span() ) {
+    auto obj = x.unwrap<Expression>().unwrap<Object>();
+    Handle<Eval> eval( obj );
+    auto result = get_or_delegate( eval, current_.value() ); // this will start the relevant eval if it's not ready
+    if ( not result ) {
+      ready = false;
     }
-    if ( not ready ) {
-      return {};
-    }
+  }
+  if ( not ready ) {
+    return {};
+  }
 
-    auto values = OwnedMutTree::allocate( data->size() );
-    for ( size_t i = 0; i < data->size(); i++ ) {
-      auto x = data->at( i );
-      auto obj = x.unwrap<Expression>().unwrap<Object>();
-      Handle<Eval> eval( obj );
-      values[i] = get_or_delegate( eval ).value().unwrap<Value>();
-    }
+  auto values = OwnedMutTree::allocate( data->size() );
+  for ( size_t i = 0; i < data->size(); i++ ) {
+    auto x = data->at( i );
+    auto obj = x.unwrap<Expression>().unwrap<Object>();
+    Handle<Eval> eval( obj );
+    values[i] = get_or_delegate( eval, current_.value() ).value().unwrap<Value>();
+  }
 
-    if ( tree.is_tag() ) {
-      return storage_.create( std::make_shared<OwnedTree>( std::move( values ) ) ).unwrap<ValueTree>().tag();
-    } else {
-      return storage_.create( std::make_shared<OwnedTree>( std::move( values ) ) ).unwrap<ValueTree>();
-    }
+  if ( tree.is_tag() ) {
+    return storage_.create( std::make_shared<OwnedTree>( std::move( values ) ) ).unwrap<ValueTree>().tag();
+  } else {
+    return storage_.create( std::make_shared<OwnedTree>( std::move( values ) ) ).unwrap<ValueTree>();
   }
 }
 
@@ -346,6 +339,8 @@ std::optional<Handle<Object>> Executor::get( Handle<Relation> name )
   if ( threads_.size() == 0 ) {
     throw HandleNotFound( name );
   }
+  auto graph = graph_.write();
+  graph->start( name );
   todo_ << name;
   return {};
 }
@@ -363,6 +358,12 @@ void Executor::put( Handle<AnyTree> name, TreeData data )
 void Executor::put( Handle<Relation> name, Handle<Object> data )
 {
   storage_.create( name, data );
+  absl::flat_hash_set<Handle<Relation>> unblocked;
+  auto graph = graph_.write();
+  graph->finish( name, unblocked );
+  for ( auto x : unblocked ) {
+    todo_ << x;
+  }
 }
 
 bool Executor::contains( Handle<Named> handle )
@@ -421,6 +422,10 @@ void Executor::visit_minrepo( Handle<T> handle,
 void Executor::load_to_storage( Handle<AnyDataType> handle )
 {
   handle::data( handle ).visit<void>( overload { []( Handle<Literal> ) { return; },
+                                                 [&]( Handle<Relation> h ) {
+                                                   if ( !contains( h ) )
+                                                     put( h, get_or_delegate( h, h ).value() );
+                                                 },
                                                  [&]( auto h ) {
                                                    if ( !contains( h ) )
                                                      put( h, get_or_delegate( h ).value() );

--- a/src/runtime/executor.cc
+++ b/src/runtime/executor.cc
@@ -357,13 +357,14 @@ void Executor::put( Handle<AnyTree> name, TreeData data )
 
 void Executor::put( Handle<Relation> name, Handle<Object> data )
 {
-  storage_.create( name, data );
   absl::flat_hash_set<Handle<Relation>> unblocked;
   auto graph = graph_.write();
   graph->finish( name, unblocked );
   for ( auto x : unblocked ) {
     todo_ << x;
   }
+  storage_.create( name, data );
+  // TODO: race condition?
 }
 
 bool Executor::contains( Handle<Named> handle )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -19,6 +19,8 @@ target_link_libraries(test-executor runtime)
 add_executable(test-distributed test-distributed.cc main.cc)
 target_link_libraries(test-distributed runtime)
 
+add_executable(test-dependency-graph test-dependency-graph.cc main.cc)
+target_link_libraries(test-dependency-graph runtime)
 
 add_executable(test-add test-add.cc main.cc)
 target_link_libraries(test-add runtime)

--- a/src/tests/test-dependency-graph.cc
+++ b/src/tests/test-dependency-graph.cc
@@ -1,0 +1,43 @@
+#include <cstdint>
+#include <glog/logging.h>
+
+#include "dependency_graph.hh"
+#include "handle.hh"
+
+using namespace std;
+
+void test( void )
+{
+  DependencyGraph graph;
+
+  Handle foo = "foo"_literal;
+  Handle bar = "bar"_literal;
+  Handle baz = "baz"_literal;
+
+  Handle otree = Handle<ObjectTree>::nil();
+
+  auto eval = []( auto x ) { return Handle<Eval>( x ); };
+  auto apply = []( auto x ) { return Handle<Apply>( x ); };
+
+  absl::flat_hash_set<DependencyGraph::Task> ready;
+  CHECK( graph.start( apply( otree ) ) );
+  CHECK( graph.contains( apply( otree ) ) );
+  graph.finish( apply( otree ), ready );
+  CHECK( not graph.contains( apply( otree ) ) );
+  CHECK( ready.empty() );
+
+  CHECK( graph.start( apply( otree ) ) );
+  CHECK( not graph.start( apply( otree ) ) );
+  CHECK( graph.add_dependency( apply( otree ), eval( foo ) ) );
+  CHECK( graph.add_dependency( apply( otree ), eval( bar ) ) );
+  CHECK( not graph.add_dependency( apply( otree ), eval( bar ) ) );
+  CHECK( not graph.start( eval( bar ) ) );
+  graph.finish( eval( bar ), ready );
+  CHECK( ready.empty() );
+  graph.finish( eval( baz ), ready );
+  CHECK( ready.empty() );
+  graph.finish( eval( foo ), ready );
+  CHECK( not ready.empty() );
+  CHECK( ready.contains( apply( otree ) ) );
+  CHECK( ready.size() == 1 );
+}


### PR DESCRIPTION
Brings back a simplified version of the old dependency graph, which the Executor now uses to deduplicate relations.