### PR TITLE
Add OnePassScheduler

### DIFF
--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -17,6 +17,7 @@ add_test(NAME u_executor COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-exec
 add_test(NAME u_distributed COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-distributed)
 add_test(NAME u_blake3 WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-blake3)
 add_test(NAME u_dependency_graph COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-dependency-graph)
+add_test(NAME u_scheduler COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-scheduler)
 
 add_test(NAME t_add COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-add)
 add_test(NAME t_fib COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-fib)

--- a/src/runtime/dependency_graph.hh
+++ b/src/runtime/dependency_graph.hh
@@ -80,4 +80,9 @@ public:
       backward_dependencies_.erase( task );
     }
   }
+
+  absl::flat_hash_set<Task> get_forward_dependencies( Task blocked ) const
+  {
+    return forward_dependencies_.at( blocked );
+  }
 };

--- a/src/runtime/relater.cc
+++ b/src/runtime/relater.cc
@@ -63,6 +63,7 @@ Relater::Relater( size_t threads, optional<shared_ptr<Runner>> runner, optional<
   : evaluator_( *this )
   , scheduler_( scheduler.has_value() ? move( scheduler.value() ) : make_shared<LocalFirstScheduler>() )
 {
+  scheduler_->set_relater( *this );
   local_ = make_shared<Executor>( *this, threads, runner );
 }
 
@@ -286,7 +287,7 @@ optional<Handle<Object>> Relater::get( Handle<Relation> name )
 
   auto works = relate( name );
   if ( !works.empty() ) {
-    scheduler_->schedule( remotes_, local_, graph_, works, name, *this );
+    scheduler_->schedule( works, name );
     return {};
   } else {
     return storage_.get( name );

--- a/src/runtime/relater.cc
+++ b/src/runtime/relater.cc
@@ -285,8 +285,12 @@ optional<Handle<Object>> Relater::get( Handle<Relation> name )
   }
 
   auto works = relate( name );
-  scheduler_->schedule( remotes_, local_, graph_, works, name, *this );
-  return {};
+  if ( !works.empty() ) {
+    scheduler_->schedule( remotes_, local_, graph_, works, name, *this );
+    return {};
+  } else {
+    return storage_.get( name );
+  }
 }
 
 void Relater::put( Handle<Named> name, BlobData data )

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -11,12 +11,16 @@ inline thread_local std::optional<Handle<Relation>> current_;
 
 class Executor;
 class Scheduler;
+class OnePassScheduler;
+class LocalFirstScheduler;
 
 class Relater
   : public MultiWorkerRuntime
   , FixRuntime
 {
   friend class Executor;
+  friend class OnePassScheduler;
+  friend class LocalFirstScheduler;
 
 private:
   SharedMutex<DependencyGraph> graph_ {};

--- a/src/runtime/scheduler.cc
+++ b/src/runtime/scheduler.cc
@@ -2,6 +2,8 @@
 #include "handle.hh"
 #include "handle_post.hh"
 #include "storage_exception.hh"
+#include "types.hh"
+#include <limits>
 #include <optional>
 
 using namespace std;
@@ -49,4 +51,154 @@ void LocalFirstScheduler::schedule( SharedMutex<vector<weak_ptr<IRuntime>>>& rem
   }
 
   throw HandleNotFound( top_level_job );
+}
+
+bool is_local( shared_ptr<IRuntime> rt )
+{
+  return rt->get_info()->link_speed == numeric_limits<double>::max();
+}
+
+void OnePassScheduler::schedule( SharedMutex<vector<weak_ptr<IRuntime>>>& remotes,
+                                 shared_ptr<IRuntime> local,
+                                 SharedMutex<DependencyGraph>& graph,
+                                 vector<Handle<Relation>>& leaf_jobs,
+                                 Handle<Relation> top_level_job,
+                                 Relater& rt )
+{
+  // If all dependencies are resolved, the job should have been completed
+  if ( leaf_jobs.empty() ) {
+    throw runtime_error( "Invalid schedule() invocation." );
+    return;
+  }
+
+  auto location = schedule_rec( remotes, local, graph, top_level_job, rt );
+  if ( !is_local( location ) ) {
+    location->get( top_level_job );
+  }
+}
+
+shared_ptr<IRuntime> OnePassScheduler::schedule_rec( SharedMutex<vector<weak_ptr<IRuntime>>>& remotes,
+                                                     shared_ptr<IRuntime> local,
+                                                     SharedMutex<DependencyGraph>& graph,
+                                                     Handle<Relation> top_level_job,
+                                                     Relater& rt )
+{
+  return top_level_job.visit<shared_ptr<IRuntime>>( overload {
+    [&]( Handle<Apply> a ) {
+      // Base case: Apply
+      auto loc = locate( remotes, local, a, rt );
+      if ( is_local( loc ) ) {
+        loc->get( a );
+      }
+      return loc;
+    },
+    [&]( Handle<Eval> e ) {
+      return handle::extract<Identification>( e.unwrap<Object>() )
+        .transform( [&]( auto ) {
+          // Base case: Eval( Identification )
+          auto loc = locate( remotes, local, e, rt );
+          if ( is_local( loc ) ) {
+            loc->get( e );
+          }
+          return loc;
+        } )
+        .or_else( [&]() -> optional<shared_ptr<IRuntime>> {
+          // Recursive case
+          auto dependencies = graph.read()->get_forward_dependencies( top_level_job );
+          unordered_map<Handle<Relation>, shared_ptr<IRuntime>> dependency_locations;
+          for ( const auto& dependency : dependencies ) {
+            dependency_locations.insert( { dependency, schedule_rec( remotes, local, graph, dependency, rt ) } );
+          }
+          auto location = locate( remotes, local, top_level_job, rt, dependency_locations );
+
+          if ( is_local( location ) ) {
+            // Get any non-local child work
+            for ( const auto& [d, dloc] : dependency_locations ) {
+              if ( !is_local( dloc ) ) {
+                dloc->get( d );
+              }
+            }
+          };
+
+          return location;
+        } )
+        .value();
+    } } );
+}
+
+shared_ptr<IRuntime> OnePassScheduler::locate(
+  SharedMutex<vector<weak_ptr<IRuntime>>>& remotes,
+  shared_ptr<IRuntime> local,
+  Handle<Relation> top_level_job,
+  Relater& rt,
+  unordered_map<Handle<Relation>, shared_ptr<IRuntime>> dependency_locations )
+{
+  if ( local->get_info()->parallelism > 0 ) {
+    return local;
+  }
+
+  Handle<Fix> root = top_level_job.visit<Handle<Fix>>(
+    overload { [&]( Handle<Apply> a ) { return a.unwrap<ObjectTree>(); },
+               [&]( Handle<Eval> e ) {
+                 return handle::extract<Identification>( e.unwrap<Object>() )
+                   .transform( []( auto h ) -> Handle<Fix> { return h.template unwrap<Value>(); } )
+                   .or_else( [&]() -> optional<Handle<Fix>> { return e.unwrap<Object>(); } )
+                   .value();
+               } } );
+
+  unordered_map<shared_ptr<IRuntime>, size_t> available_data;
+
+  // Calculate available data size on each remote
+  for ( const auto& remote : remotes.read().get() ) {
+    auto locked_remote = remote.lock();
+    // If remote already contains the result
+    if ( locked_remote->contains( top_level_job ) ) {
+      return locked_remote;
+    }
+
+    if ( locked_remote->get_info()->parallelism > 0 ) {
+      size_t contained_size = 0;
+      rt.visit_minrepo( root, [&]( Handle<AnyDataType> handle ) {
+        contained_size += handle.visit<size_t>( []( auto h ) { return handle::size( h ); } );
+      } );
+      available_data.insert( { locked_remote, contained_size } );
+    }
+  }
+
+  // Calculate dependency data size on each remote
+  for ( auto& [task, location] : dependency_locations ) {
+    auto dependency_size = const_cast<Handle<Relation>&>( task ).visit<size_t>(
+      overload { [&]( Handle<Apply> ) {
+                  // TODO: estimate apply output size
+                  return 0;
+                },
+                 [&]( Handle<Eval> e ) -> size_t {
+                   return handle::extract<Identification>( e.unwrap<Object>() )
+                     .transform( []( auto h ) -> size_t { return handle::size( h ); } )
+                     .or_else( []() -> optional<size_t> { return 0; } )
+                     .value();
+                 } } );
+
+    if ( available_data.contains( location ) ) {
+      available_data.at( location ) += dependency_size;
+    }
+  }
+
+  // Choose the remote with largest available data
+  size_t max_available_size = 0;
+  size_t max_parallelism = 0;
+  shared_ptr<IRuntime> chosen_remote;
+
+  for ( const auto& [location, available_size] : available_data ) {
+    if ( available_size > max_available_size ) {
+      max_available_size = available_size;
+      max_parallelism = location->get_info()->parallelism;
+      chosen_remote = location;
+    } else if ( available_size == max_available_size && location->get_info()->parallelism > max_parallelism ) {
+      max_parallelism = location->get_info()->parallelism;
+      chosen_remote = location;
+    }
+  }
+
+  return chosen_remote;
 }

--- a/src/runtime/scheduler.hh
+++ b/src/runtime/scheduler.hh
@@ -39,3 +39,27 @@ public:
                          Handle<Relation> top_level_job,
                          Relater& rt ) override;
 };
+
+class OnePassScheduler : public Scheduler
+{
+  std::shared_ptr<IRuntime> schedule_rec( SharedMutex<std::vector<std::weak_ptr<IRuntime>>>& remotes,
+                                          std::shared_ptr<IRuntime> local,
+                                          SharedMutex<DependencyGraph>& graph,
+                                          Handle<Relation> top_level_job,
+                                          Relater& rt );
+
+  std::shared_ptr<IRuntime> locate(
+    SharedMutex<std::vector<std::weak_ptr<IRuntime>>>& remotes,
+    std::shared_ptr<IRuntime> local,
+    Handle<Relation> job,
+    Relater& rt,
+    std::unordered_map<Handle<Relation>, std::shared_ptr<IRuntime>> dependency_locations = {} );
+
+public:
+  virtual void schedule( SharedMutex<std::vector<std::weak_ptr<IRuntime>>>& remotes,
+                         std::shared_ptr<IRuntime> local,
+                         SharedMutex<DependencyGraph>& graph,
+                         std::vector<Handle<Relation>>& leaf_jobs,
+                         Handle<Relation> top_level_job,
+                         Relater& rt ) override;
+};

--- a/src/runtime/scheduler.hh
+++ b/src/runtime/scheduler.hh
@@ -39,7 +39,7 @@ class OnePassScheduler : public Scheduler
 
   std::shared_ptr<IRuntime> locate(
     Handle<Relation> job,
-    std::unordered_map<Handle<Relation>, std::shared_ptr<IRuntime>> dependency_locations = {} );
+    const std::unordered_map<Handle<Relation>, std::shared_ptr<IRuntime>>& dependency_locations );
 
 public:
   virtual void schedule( std::vector<Handle<Relation>>& leaf_jobs, Handle<Relation> top_level_job ) override;

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -135,6 +135,40 @@ public:
       visited.insert( handle );
     }
   }
+
+  // Stop visiting recursively if visitor( Tree ) returns true
+  template<FixType T>
+  void early_stop_visit_minrepo( Handle<T> handle,
+                                 std::function<bool( Handle<AnyDataType> )> visitor,
+                                 std::unordered_set<Handle<Fix>> visited = {} )
+  {
+    if ( visited.contains( handle ) )
+      return;
+    if constexpr ( std::same_as<T, Literal> )
+      return;
+
+    if constexpr ( Handle<T>::is_fix_sum_type ) {
+      if constexpr ( not( std::same_as<T, Thunk> or std::same_as<T, Encode> or std::same_as<T, ValueTreeRef>
+                          or std::same_as<T, ObjectTreeRef> ) )
+        std::visit( [&]( const auto x ) { early_stop_visit_minrepo( x, visitor, visited ); }, handle.get() );
+
+    } else {
+      VLOG( 2 ) << "visiting " << handle;
+      auto res = visitor( handle );
+      visited.insert( handle );
+
+      if ( res )
+        return;
+
+      if constexpr ( FixTreeType<T> ) {
+        // Having the handle means that the data presents in storage
+        auto tree = get( handle );
+        for ( const auto& element : tree.value()->span() ) {
+          visit_minrepo( element, visitor, visited );
+        }
+      }
+    }
+  }
 };
 
 class MultiWorkerRuntime : public IRuntime

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -164,7 +164,7 @@ public:
         // Having the handle means that the data presents in storage
         auto tree = get( handle );
         for ( const auto& element : tree.value()->span() ) {
-          visit_minrepo( element, visitor, visited );
+          early_stop_visit_minrepo( element, visitor, visited );
         }
       }
     }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -22,6 +22,9 @@ target_link_libraries(test-distributed runtime)
 add_executable(test-dependency-graph test-dependency-graph.cc main.cc)
 target_link_libraries(test-dependency-graph runtime)
 
+add_executable(test-scheduler test-scheduler.cc main.cc)
+target_link_libraries(test-scheduler runtime)
+
 add_executable(test-add test-add.cc main.cc)
 target_link_libraries(test-add runtime)
 

--- a/src/tests/test-scheduler.cc
+++ b/src/tests/test-scheduler.cc
@@ -1,0 +1,152 @@
+#include "handle.hh"
+#include "handle_post.hh"
+#include "interface.hh"
+#include "relater.hh"
+#include "runtimestorage.hh"
+#include "scheduler.hh"
+#include "test.hh"
+
+#include <cstdio>
+#include <memory>
+
+using namespace std;
+
+class FakeRuntime : public IRuntime
+{
+public:
+  RuntimeStorage storage_ {};
+  vector<Handle<Relation>> todos_ {};
+  uint32_t parallelism_ {};
+
+  optional<BlobData> get( Handle<Named> name ) override { return storage_.get( name ); };
+  optional<TreeData> get( Handle<AnyTree> name ) override { return storage_.get( name ); };
+  optional<Handle<Object>> get( Handle<Relation> name ) override
+  {
+    todos_.push_back( name );
+    return {};
+  }
+
+  void put( Handle<Named> name, BlobData data ) override { storage_.create( data, name ); }
+  void put( Handle<AnyTree> name, TreeData data ) override { storage_.create( data, name ); }
+  void put( Handle<Relation> name, Handle<Object> data ) override { storage_.create( data, name ); }
+
+  bool contains( Handle<Named> handle ) override { return storage_.contains( handle ); }
+  bool contains( Handle<AnyTree> handle ) override { return storage_.contains( handle ); }
+  bool contains( Handle<Relation> handle ) override { return storage_.contains( handle ); }
+
+  virtual std::optional<Info> get_info() override { return Info { .parallelism = parallelism_, .link_speed = 10 }; }
+};
+
+// Work: Handle<Eval>( Handle<Application>( Handle<ExpressionTree>( uint32_t( 1 ), Handle<Strict>(
+// Handle<Identification>( Large Object 0 ) ), Handle<Strict>( Handle<Identification>( Large Object 1 ) ) ) ))
+// Machine 0: 1 parallelism + Object 0 and Object 1
+// Machine 1: 10 parallelism + Object 0 and Object 1
+// Expected outcome: Whole work is assgined to machine 1 for higher parallelism
+void case_one( void )
+{
+  shared_ptr<Relater> rt = make_shared<Relater>( 1, make_shared<PointerRunner>(), make_shared<OnePassScheduler>() );
+  shared_ptr<FakeRuntime> fake_worker = make_shared<FakeRuntime>();
+  fake_worker->parallelism_ = 1;
+
+  Handle<ValueTree> system_dep_tree = rt->labeled( "system-dep-tree" )
+                                        .try_into<Expression>()
+                                        .and_then( []( auto h ) { return h.template try_into<Object>(); } )
+                                        .and_then( []( auto h ) { return h.template try_into<Value>(); } )
+                                        .and_then( []( auto h ) { return h.template try_into<ValueTree>(); } )
+                                        .value();
+  Handle<ValueTree> clang_dep_tree = rt->labeled( "clang-dep-tree" )
+                                       .try_into<Expression>()
+                                       .and_then( []( auto h ) { return h.template try_into<Object>(); } )
+                                       .and_then( []( auto h ) { return h.template try_into<Value>(); } )
+                                       .and_then( []( auto h ) { return h.template try_into<ValueTree>(); } )
+                                       .value();
+
+  fake_worker->put( system_dep_tree, make_shared<OwnedTree>( OwnedMutTree::allocate( 1 ) ) );
+  fake_worker->put( clang_dep_tree, make_shared<OwnedTree>( OwnedMutTree::allocate( 1 ) ) );
+  rt->add_worker( fake_worker );
+
+  auto task = Handle<Eval>(
+    Handle<Application>( handle::upcast( tree( *rt,
+                                               1_literal32,
+                                               Handle<Strict>( Handle<Identification>( system_dep_tree ) ),
+                                               Handle<Strict>( Handle<Identification>( clang_dep_tree ) ) ) ) ) );
+
+  rt->get( task );
+
+  if ( fake_worker->todos_.size() != 1 or fake_worker->todos_.front() != Handle<Relation>( task ) ) {
+    fprintf( stderr, "Case 1: Wrong post condition" );
+    exit( 1 );
+  }
+}
+
+const std::string de_bello_gallico
+  = "Gallia est omnis divisa in partes tres, quarum unam incolunt Belgae, aliam Aquitani, tertiam qui ipsorum "
+    "lingua Celtae, nostra Galli appellantur. Hi omnes lingua, institutis, legibus inter se differunt. Gallos ab "
+    "Aquitanis Garumna flumen, a Belgis Matrona et Sequana dividit. Horum omnium fortissimi sunt Belgae, propterea "
+    "quod a cultu atque humanitate provinciae longissime absunt, minimeque ad eos mercatores saepe commeant atque "
+    "ea quae ad effeminandos animos pertinent important, proximique sunt Germanis, qui trans Rhenum incolunt, "
+    "quibuscum continenter bellum gerunt. Qua de causa Helvetii quoque reliquos Gallos virtute praecedunt, quod "
+    "fere cotidianis proeliis cum Germanis contendunt, cum aut suis finibus eos prohibent aut ipsi in eorum "
+    "finibus bellum gerunt. Eorum una pars, quam Gallos obtinere dictum est, initium capit a flumine Rhodano, "
+    "continetur Garumna flumine, Oceano, finibus Belgarum, attingit etiam ab Sequanis et Helvetiis flumen Rhenum, "
+    "vergit ad septentriones. Belgae ab extremis Galliae finibus oriuntur, pertinent ad inferiorem partem fluminis "
+    "Rheni, spectant in septentrionem et orientem solem. Aquitania a Garumna flumine ad Pyrenaeos montes et eam "
+    "partem Oceani quae est ad Hispaniam pertinet; spectat inter occasum solis et septentriones.";
+
+// Work: Handle<Eval>( Handle<Application>( Handle<ExpressionTree>( uint32_t( 1 ), Handle<Strict>(
+// Handle<Identification>( Large Object 0 ) ) ) ) ) Machine 0: 1 parallelism Machine 1: 1 parallelism + Object 0
+// Expected outcome: Whole work is assgined to machine 1
+void case_two( void )
+{
+  shared_ptr<Relater> rt = make_shared<Relater>( 1, make_shared<PointerRunner>(), make_shared<OnePassScheduler>() );
+  shared_ptr<FakeRuntime> fake_worker = make_shared<FakeRuntime>();
+  fake_worker->parallelism_ = 1;
+
+  auto handle = fake_worker->storage_.create( de_bello_gallico );
+  rt->add_worker( fake_worker );
+
+  auto task = Handle<Eval>( Handle<Application>(
+    handle::upcast( tree( *rt, 1_literal32, Handle<Strict>( Handle<Identification>( handle ) ) ) ) ) );
+
+  rt->get( task );
+
+  if ( fake_worker->todos_.size() != 1 or fake_worker->todos_.front() != Handle<Relation>( task ) ) {
+    fprintf( stderr, "Case 2: Wrong post condition" );
+    exit( 1 );
+  }
+}
+
+// Work: Handle<Eval>( Handle<Application>( Handle<ExpressionTree>( Handle<Strict>( Handle<Identification>( Blob 0
+// ), Handle<Strict>( Handle<Identification>( Blob 1 ) ) ) ) ) Machine 0: 1 parallelism + Blob 0 Machine 1: 1
+// parallelism + Blob 1 Blob 0 > Blob 1 Expected outcome: Handle<Eval>( Handle<Identification>( large object 1 ) )
+// is assigned to machine 1
+void case_three( void )
+{
+  shared_ptr<Relater> rt = make_shared<Relater>( 1, make_shared<PointerRunner>(), make_shared<OnePassScheduler>() );
+  shared_ptr<FakeRuntime> fake_worker = make_shared<FakeRuntime>();
+  fake_worker->parallelism_ = 1;
+
+  auto handle = fake_worker->storage_.create( de_bello_gallico );
+  rt->add_worker( fake_worker );
+
+  auto task = Handle<Eval>( Handle<Application>( handle::upcast(
+    tree( *rt,
+          Handle<Strict>(
+            handle::extract<Identification>( make_identification( rt->labeled( "c-to-elf-fix-wasm" ) ) ).value() ),
+          Handle<Strict>( Handle<Identification>( handle ) ) ) ) ) );
+  rt->get( task );
+
+  if ( fake_worker->todos_.size() != 1
+       or fake_worker->todos_.front() != Handle<Relation>( Handle<Eval>( Handle<Identification>( handle ) ) ) ) {
+    cout << "fake_worker->todos_.size " << fake_worker->todos_.size() << endl;
+    fprintf( stderr, "Case 3: Wrong post condition" );
+    exit( 1 );
+  }
+}
+
+void test( void )
+{
+  case_one();
+  case_two();
+  case_three();
+}


### PR DESCRIPTION
* OnePassScheduler makes scheduling decision from leaves of the dependency tree. Location decision of dependees affects the decision of the depender, but not the other way around.
* For a task, OnePassScheduler makes the decision by calculating the absent size of the task on each available worker with non-zero parallelism, which is the sum of objects in the known minrepo and the task's dependee's output size.