### PR TITLE
Refactor load to actually conform with fix.hs

### DIFF
--- a/src/handle/generate.c
+++ b/src/handle/generate.c
@@ -11,6 +11,7 @@ typedef struct Type
   const char* name;
   size_t bits;
   bool fix;
+  bool tree_ref;
   size_t num_options;
   struct Type* options[];
 } Type;
@@ -54,6 +55,13 @@ Type* make_sum( const char* name, size_t n, ... )
 Type* make_wrapper( const char* name, const Type* type )
 {
   return make_sum( name, 1, type );
+}
+
+Type* make_tree_ref( const char* name, const Type* type )
+{
+  Type* res = make_sum( name, 1, type );
+  res->tree_ref = true;
+  return res;
 }
 
 void print_type( const Type* type )
@@ -123,10 +131,20 @@ void serialize_constructors( const Type* type, const unsigned offset )
 
   if ( type->num_options == 1 ) {
     const Type* option = type->options[0];
-    printf( "\tinline Handle<%s>(const Handle<%s> &base) : "
-            "content(base.content) {}\n\n",
-            type->name,
-            option->name );
+    if ( type->tree_ref ) {
+      printf( "\tinline Handle<%s>(const Handle<%s> &base, size_t size) : "
+              "content(base.content) {\n"
+              "\t\tassert( ( size & 0xffff000000000000 ) == 0 );\n"
+              "\t\t( *(u64x4*)&content )[3] = ( ( *(u64x4*)&content )[3] & 0xffff000000000000 ) | size;\n"
+              "\t}\n",
+              type->name,
+              option->name );
+    } else {
+      printf( "\tinline Handle<%s>(const Handle<%s> &base) : "
+              "content(base.content) {}\n\n",
+              type->name,
+              option->name );
+    }
   } else {
     for ( unsigned i = 0; i < type->num_options; i++ ) {
       const Type* option = type->options[i];
@@ -144,12 +162,21 @@ void serialize_constructors( const Type* type, const unsigned offset )
     // wrapper types cause ambiguous implicit conversions, so we don't allow it
     if ( option->num_options != 1 ) {
       printf( "\ttemplate<FixType T>\n" );
-      printf( "\tinline Handle<%s>(const Handle<T> &base) requires std::convertible_to<Handle<T>, "
-              "Handle<%s>>: "
-              "Handle(Handle<%s>(base)) {}\n\n",
-              type->name,
-              option->name,
-              option->name );
+      if ( type->tree_ref ) {
+        printf( "\tinline Handle<%s>(const Handle<T> &base, size_t size) requires std::convertible_to<Handle<T>, "
+                "Handle<%s>>: "
+                "Handle(Handle<%s>(base), size) {}\n\n",
+                type->name,
+                option->name,
+                option->name );
+      } else {
+        printf( "\tinline Handle<%s>(const Handle<T> &base) requires std::convertible_to<Handle<T>, "
+                "Handle<%s>>: "
+                "Handle(Handle<%s>(base)) {}\n\n",
+                type->name,
+                option->name,
+                option->name );
+      }
     }
   }
 }
@@ -282,7 +309,7 @@ body:
   printf( "template<>\n" );
   printf( "struct Handle<%s> {\n", type->name );
   printf( "\tconstexpr static bool is_fix_data_type = true;\n" );
-  printf( "\tconstexpr static bool is_fix_sum_type = true;\n" );
+  printf( "\tconstexpr static bool is_fix_sum_type = %s;\n", type->tree_ref ? "false" : "true" );
   printf( "\tconstexpr static bool is_fix_wrapper = %s;\n", wrapper ? "true" : "false" );
   if ( !wrapper ) {
     serialize_mask( offset, tag_bits );
@@ -293,23 +320,41 @@ body:
     serialize_enum( type, offset, tag_bits );
   }
   serialize_constructors( type, offset );
-  serialize_unwrap( type );
-  serialize_try_into( type );
 
-  serialize_get( type );
+  if ( !type->tree_ref ) {
+    serialize_unwrap( type );
+    serialize_try_into( type );
+
+    serialize_get( type );
+  }
 
   printf( "\ttemplate<FixType A>\n" );
   printf( "\tinline Handle<A> into() const requires "
           "std::constructible_from<Handle<A>, Handle<%s>> {\n",
           type->name );
   printf( "\t\treturn Handle<A>(*this);\n" );
+  printf( "\t}\n\n" );
+
+  printf( "\ttemplate<FixType A>\n" );
+  printf( "\tinline Handle<A> into(size_t size) const requires "
+          "std::constructible_from<Handle<A>, Handle<%s>, size_t> {\n",
+          type->name );
+  printf( "\t\treturn Handle<A>(*this,size);\n" );
   printf( "\t}\n" );
+
+  if ( type->tree_ref ) {
+    printf( "\n\tinline size_t size() const { return ( (u64x4)content )[3] & 0xffffffffffff; }\n" );
+  }
 
   printf( "};\n\n" );
 
   printf( "static inline std::ostream& operator<<(std::ostream& os, const Handle<%s>& h) {\n", type->name );
   printf( "\tos << \"%s (\";\n", type->name );
-  printf( "\tstd::visit([&](auto x) {os << x;}, h.get());\n" );
+  if ( type->tree_ref ) {
+    printf( "\tos << h.content;\n" );
+  } else {
+    printf( "\tstd::visit([&](auto x) {os << x;}, h.get());\n" );
+  }
   printf( "\tos << \")\";\n" );
   printf( "\treturn os;\n" );
   printf( "}\n\n" );
@@ -343,8 +388,8 @@ int main( int argc, char** argv )
   const Type* otree = make_terminal( "ObjectTree", 240 + 1 + 1 );     // hash + tag + is_local
   const Type* etree = make_terminal( "ExpressionTree", 240 + 1 + 1 ); // hash + tag + is_local
 
-  const Type* vref = make_wrapper( "ValueTreeRef", vtree );
-  const Type* oref = make_wrapper( "ObjectTreeRef", otree );
+  const Type* vref = make_tree_ref( "ValueTreeRef", vtree );
+  const Type* oref = make_tree_ref( "ObjectTreeRef", otree );
 
   const Type* literal = make_terminal( "Literal", 240 + 5 ); // hash + size
   const Type* named = make_terminal( "Named", 240 + 1 );     // hash + is_local

--- a/src/handle/generate.c
+++ b/src/handle/generate.c
@@ -344,6 +344,7 @@ body:
 
   if ( type->tree_ref ) {
     printf( "\n\tinline size_t size() const { return ( (u64x4)content )[3] & 0xffffffffffff; }\n" );
+    printf( "\n\tinline bool is_tag() const { return ( content[30] >> 6 ) & 1; }\n" );
   }
 
   printf( "};\n\n" );

--- a/src/handle/handle_post.hh
+++ b/src/handle/handle_post.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include <concepts>
 #include <variant>
 
 #include "handle.hh"
@@ -70,6 +71,20 @@ static inline size_t size( Handle<T> handle )
     return handle.size();
   } else {
     return std::visit( []( const auto x ) { return size( x ); }, handle.get() );
+  }
+}
+
+template<typename T>
+static inline size_t byte_size( Handle<T> handle )
+{
+  if constexpr ( std::same_as<T, Relation> ) {
+    return sizeof( Handle<Fix> );
+  } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> ) {
+    return 0;
+  } else if constexpr ( not Handle<T>::is_fix_sum_type ) {
+    return handle.size();
+  } else {
+    return std::visit( []( const auto x ) { return byte_size( x ); }, handle.get() );
   }
 }
 

--- a/src/handle/handle_pre.hh
+++ b/src/handle/handle_pre.hh
@@ -4,4 +4,5 @@
 #include "literals.hh"  // IWYU pragma: export
 #include "operators.hh" // IWYU pragma: export
 #include "tree.hh"      // IWYU pragma: export
+#include "treeref.hh"   // IWYU pragma: export
 #include "types.hh"     // IWYU pragma: export

--- a/src/handle/operators.hh
+++ b/src/handle/operators.hh
@@ -94,6 +94,25 @@ inline std::ostream& operator<<( std::ostream& os, const Handle<Tree<T>>& h )
   return os;
 }
 
+template<typename T>
+inline std::ostream& operator<<( std::ostream& os, const Handle<TreeRef<T>>& h )
+{
+  if constexpr ( std::same_as<T, Value> ) {
+    os << "Value";
+  } else if constexpr ( std::same_as<T, Object> ) {
+    os << "Object";
+  } else if constexpr ( std::same_as<T, Expression> ) {
+    os << "Expression";
+  }
+  os << "TreeRef " << h.size() << " ";
+  if ( h.is_local() ) {
+    os << "(Local " << h.local_name() << ")";
+  } else {
+    os << "(Canonical " << h.hash() << ")";
+  }
+  return os;
+}
+
 namespace std {
 template<typename T>
 struct hash<Handle<T>>

--- a/src/handle/operators.hh
+++ b/src/handle/operators.hh
@@ -101,8 +101,7 @@ struct hash<Handle<T>>
   size_t operator()( const Handle<T>& x ) const
   {
     u64x4 dwords = (u64x4)x.content;
-    return hash<uint64_t>()( dwords[0] ) ^ hash<uint64_t>()( dwords[1] ) ^ hash<uint64_t>()( dwords[2] )
-           ^ hash<uint64_t>()( dwords[3] );
+    return hash<uint64_t>()( dwords[0] ) ^ hash<uint64_t>()( dwords[1] ) ^ hash<uint64_t>()( dwords[2] );
   }
 };
 }

--- a/src/handle/tree.hh
+++ b/src/handle/tree.hh
@@ -100,6 +100,12 @@ public:
     return Handle<A>( *this );
   }
 
+  template<typename A>
+  inline Handle<A> into( size_t size ) const requires std::constructible_from<Handle<A>, Handle<Tree<T>>, size_t>
+  {
+    return Handle<A>( *this, size );
+  }
+
   template<typename A, typename B, typename... Ts>
   inline auto into() const requires std::constructible_from<Handle<A>, Handle<Tree<T>>>
   {

--- a/src/handle/treeref.hh
+++ b/src/handle/treeref.hh
@@ -1,0 +1,101 @@
+#pragma once
+#include <cassert>
+#include <concepts> // IWYU pragma: keep
+#include <cstddef>
+#include <cstdint>
+
+#include "types.hh"
+
+template<typename T>
+struct TreeRef;
+
+template<typename T>
+struct Handle<TreeRef<T>>
+{
+  constexpr static bool is_fix_data_type = true;
+  constexpr static bool is_fix_sum_type = false;
+  constexpr static bool is_fix_wrapper = true;
+
+  u8x32 content;
+
+  using element_type = T;
+
+private:
+  Handle( const u8x32 content )
+    : content( content )
+  {}
+
+  inline Handle( const u8x32 hash, uint64_t size, bool tag = false )
+    : content( hash )
+  {
+    assert( ( size & 0xffff000000000000 ) == 0 );
+    ( *(u64x4*)&content )[3] = size;
+    content[30] |= ( tag << 6 );
+  }
+
+  inline Handle( uint64_t local_name, uint64_t size, bool tag = false )
+    : content()
+  {
+    ( *(u64x4*)&content )[0] = local_name;
+    assert( ( size & 0xffff000000000000 ) == 0 );
+    ( *(u64x4*)&content )[3] = size;
+    content[30] |= ( 1 << 7 );
+    content[30] |= ( tag << 6 );
+  }
+
+public:
+  inline u8x32 hash() const
+  {
+    u64x4 hash = (u64x4)content;
+    hash[3] = 0;
+    return (u8x32)hash;
+  }
+
+  inline size_t size() const { return ( (u64x4)content )[3] & 0xffffffffffff; }
+  inline bool empty() const { return size() == 0; }
+  inline bool is_local() const { return ( content[30] >> 7 ) & 1; }
+  inline bool is_tag() const { return ( content[30] >> 6 ) & 1; }
+  inline uint64_t local_name() const { return ( (u64x4)content )[0]; }
+
+  static inline Handle<TreeRef<T>> forge( u8x32 content ) { return { content }; }
+
+  inline Handle( const Handle<Tree<T>>& base, size_t size )
+    : content( base.hash() )
+  {
+    assert( ( size & 0xffff000000000000 ) == 0 );
+    ( *(u64x4*)&content )[3] = size;
+  }
+
+  template<typename A>
+  requires Handle<A>::is_fix_data_type
+  inline Handle( const Handle<A>& base, size_t size ) requires std::convertible_to<Handle<A>, Handle<Tree<T>>>
+    : Handle( Handle<Tree<T>>( base ), size )
+  {}
+
+  explicit inline operator Handle<ObjectTreeRef>() const requires std::same_as<T, Value>
+  {
+    if ( is_local() ) {
+      return { local_name(), size(), is_tag() };
+    } else {
+      return { hash(), size(), is_tag() };
+    }
+  }
+
+  template<typename A>
+  inline Handle<A> into() const requires std::constructible_from<Handle<A>, Handle<TreeRef<T>>>
+  {
+    return Handle<A>( *this );
+  }
+
+  template<typename A>
+  inline Handle<A> into( size_t size ) const requires std::constructible_from<Handle<A>, Handle<TreeRef<T>>, size_t>
+  {
+    return Handle<A>( *this, size );
+  }
+
+  template<typename A, typename B, typename... Ts>
+  inline auto into() const requires std::constructible_from<Handle<A>, Handle<TreeRef<T>>>
+  {
+    return Handle<A>( *this ).template into<B, Ts...>();
+  }
+};

--- a/src/handle/types.hh
+++ b/src/handle/types.hh
@@ -15,6 +15,11 @@ struct Handle;
 template<typename T>
 struct Tree;
 
+template<typename T>
+struct TreeRef;
+
 using ValueTree = Tree<Value>;
 using ObjectTree = Tree<Object>;
 using ExpressionTree = Tree<Expression>;
+using ValueTreeRef = TreeRef<Value>;
+using ObjectTreeRef = TreeRef<Object>;

--- a/src/runtime/evaluator.hh
+++ b/src/runtime/evaluator.hh
@@ -10,6 +10,8 @@ public:
   using Result = std::optional<Handle<T>>;
 
   virtual Result<Fix> load( Handle<AnyDataType> value ) = 0;
+  virtual Result<AnyTree> load( Handle<AnyTreeRef> treeref ) = 0;
+  virtual Handle<AnyTreeRef> ref( Handle<AnyTree> tree ) = 0;
   virtual Result<Object> apply( Handle<ObjectTree> combination ) = 0;
   virtual Result<Value> evalStrict( Handle<Object> expression ) = 0;
   virtual Result<Object> evalShallow( Handle<Object> expression ) = 0;

--- a/src/runtime/relater.cc
+++ b/src/runtime/relater.cc
@@ -112,14 +112,7 @@ Handle<AnyTreeRef> Relater::ref( Handle<AnyTree> tree )
   if ( !storage_.contains( tree ) ) {
     throw HandleNotFound( handle::fix( tree ) );
   }
-
-  return tree.visit<Handle<AnyTreeRef>>( overload {
-    [&]( Handle<ValueTree> t ) { return t.into<ValueTreeRef>( storage_.get( tree )->size() ); },
-    [&]( Handle<ObjectTree> t ) { return t.into<ObjectTreeRef>( storage_.get( tree )->size() ); },
-    [&]( Handle<ExpressionTree> ) -> Handle<AnyTreeRef> {
-      throw runtime_error( "ExpressionTree cannot be reffed" );
-    },
-  } );
+  return storage_.ref( tree );
 }
 
 Relater::Result<Object> Relater::apply( Handle<ObjectTree> combination )
@@ -409,9 +402,9 @@ bool Relater::contains( Handle<Relation> handle )
   return storage_.contains( handle ) || repository_.contains( handle );
 }
 
-std::optional<Handle<AnyTree>> Relater::contains( Handle<AnyTreeRef> )
+std::optional<Handle<AnyTree>> Relater::contains( Handle<AnyTreeRef> handle )
 {
-  throw runtime_error( "Unimplemented" );
+  return storage_.contains( handle ).or_else( [&]() { return repository_.contains( handle ); } );
 }
 
 bool Relater::contains( const std::string_view label )

--- a/src/storage/handle_util.hh
+++ b/src/storage/handle_util.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include <cwchar>
 #include <string_view>
 
 #include "blake3.hh"
@@ -27,16 +28,26 @@ static inline FixKind tree_kind( const TreeData& tree )
   return kind;
 }
 
+static inline size_t tree_size( const TreeData& tree )
+{
+  size_t size = 0;
+  for ( size_t i = 0; i < tree->size(); i++ ) {
+    size += byte_size( tree->at( i ) );
+  }
+  size += tree->size() * sizeof( Handle<Fix> );
+  return size;
+}
+
 static inline Handle<AnyTree> create( const TreeData& data )
 {
   u8x32 hash = blake3::encode( std::as_bytes( data->span() ) );
   switch ( tree_kind( data ) ) {
     case FixKind::Value:
-      return Handle<ValueTree>( hash, data->size() );
+      return Handle<ValueTree>( hash, tree_size( data ) );
     case FixKind::Object:
-      return Handle<ObjectTree>( hash, data->size() );
+      return Handle<ObjectTree>( hash, tree_size( data ) );
     case FixKind::Expression:
-      return Handle<ExpressionTree>( hash, data->size() );
+      return Handle<ExpressionTree>( hash, tree_size( data ) );
     case FixKind::Fix:
       throw std::runtime_error( "invalid contents of tree" );
   }

--- a/src/storage/handle_util.hh
+++ b/src/storage/handle_util.hh
@@ -6,6 +6,7 @@
 #include "handle.hh"
 #include "handle_post.hh"
 #include "object.hh"
+#include "types.hh"
 
 namespace handle {
 static inline Handle<Blob> create( const BlobData& blob )
@@ -53,4 +54,19 @@ static inline Handle<AnyTree> create( const TreeData& data )
   }
   __builtin_unreachable();
 }
+
+struct tree_equal
+{
+  constexpr bool operator()( const Handle<ExpressionTree>& lhs, const Handle<ExpressionTree>& rhs ) const
+  {
+    static constexpr u64x4 mask
+      = { 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffff000000000000 };
+    u64x4 pxor = (u64x4)( lhs.content ^ rhs.content ) & mask;
+#ifdef __AVX__
+    return _mm256_testz_si256( (__m256i)pxor, (__m256i)pxor );
+#else
+    return ( xored[0] | xored[1] | xored[2] | xored[3] ) == 0;
+#endif
+  }
 };
+}

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -94,6 +94,8 @@ public:
   virtual bool contains( Handle<Relation> handle ) = 0;
   ///}@
 
+  virtual std::optional<Handle<AnyTree>> contains( Handle<AnyTreeRef> ) { return {}; }
+
   /**
    * Gets metadata about this IDataLoader.
    *
@@ -118,10 +120,11 @@ public:
       return;
 
     if constexpr ( Handle<T>::is_fix_sum_type ) {
-      if constexpr ( not( std::same_as<T, Thunk> or std::same_as<T, Encode> or std::same_as<T, ValueTreeRef>
-                          or std::same_as<T, ObjectTreeRef> ) )
+      if constexpr ( not( std::same_as<T, Thunk> or std::same_as<T, Encode> ) )
         std::visit( [&]( const auto x ) { visit_minrepo( x, visitor, visited ); }, handle.get() );
 
+    } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> ) {
+      return;
     } else {
       if constexpr ( FixTreeType<T> ) {
         // Having the handle means that the data presents in storage
@@ -148,10 +151,11 @@ public:
       return;
 
     if constexpr ( Handle<T>::is_fix_sum_type ) {
-      if constexpr ( not( std::same_as<T, Thunk> or std::same_as<T, Encode> or std::same_as<T, ValueTreeRef>
-                          or std::same_as<T, ObjectTreeRef> ) )
+      if constexpr ( not( std::same_as<T, Thunk> or std::same_as<T, Encode> ) )
         std::visit( [&]( const auto x ) { early_stop_visit_minrepo( x, visitor, visited ); }, handle.get() );
 
+    } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> ) {
+      return;
     } else {
       VLOG( 2 ) << "visiting " << handle;
       auto res = visitor( handle );

--- a/src/storage/repository.cc
+++ b/src/storage/repository.cc
@@ -238,6 +238,11 @@ bool Repository::contains( Handle<Relation> handle )
   }
 }
 
+std::optional<Handle<AnyTree>> Repository::contains( Handle<AnyTreeRef> )
+{
+  throw runtime_error( "Unimplemented" );
+}
+
 #if 0
 bool Repository::contains( Handle<Fix> handle )
 {

--- a/src/storage/repository.cc
+++ b/src/storage/repository.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "base16.hh"
+#include "handle_post.hh"
 #include "repository.hh"
 #include "storage_exception.hh"
 
@@ -84,13 +85,27 @@ std::optional<BlobData> Repository::get( Handle<Named> name )
 
 std::optional<TreeData> Repository::get( Handle<AnyTree> name )
 {
-  auto fix = name.visit<Handle<Fix>>( []( auto x ) { return x; } );
+  auto vtree = name.visit<Handle<Fix>>( []( auto h ) -> Handle<ValueTree> {
+    return { h.content, h.size(), h.is_tag() };
+  } );
+  auto otree = name.visit<Handle<Fix>>( []( auto h ) -> Handle<ObjectTree> {
+    return { h.content, h.size(), h.is_tag() };
+  } );
+  auto etree = name.visit<Handle<Fix>>( []( auto h ) -> Handle<ExpressionTree> {
+    return { h.content, h.size(), h.is_tag() };
+  } );
   try {
-    VLOG( 1 ) << "loading " << fix.content << " from disk";
-    assert( not handle::is_local( fix ) );
-    return make_shared<OwnedTree>( repo_ / "data" / base16::encode( fix.content ) );
+    VLOG( 1 ) << "loading " << handle::fix( name ).content << " from disk";
+    assert( not handle::is_local( name ) );
+    if ( fs::exists( repo_ / "data" / base16::encode( vtree.content ) ) ) {
+      return make_shared<OwnedTree>( repo_ / "data" / base16::encode( vtree.content ) );
+    } else if ( fs::exists( repo_ / "data" / base16::encode( otree.content ) ) ) {
+      return make_shared<OwnedTree>( repo_ / "data" / base16::encode( otree.content ) );
+    } else {
+      return make_shared<OwnedTree>( repo_ / "data" / base16::encode( etree.content ) );
+    }
   } catch ( std::filesystem::filesystem_error& ) {
-    throw HandleNotFound( fix );
+    throw HandleNotFound( handle::fix( name ) );
   }
 }
 
@@ -223,7 +238,18 @@ bool Repository::contains( Handle<Named> handle )
 bool Repository::contains( Handle<AnyTree> handle )
 {
   try {
-    return fs::exists( repo_ / "data" / base16::encode( handle::fix( handle ).content ) );
+    auto vtree = handle.visit<Handle<ValueTree>>( []( auto h ) -> Handle<ValueTree> {
+      return { h.content, h.size(), h.is_tag() };
+    } );
+    auto otree = handle.visit<Handle<ObjectTree>>( []( auto h ) -> Handle<ObjectTree> {
+      return { h.content, h.size(), h.is_tag() };
+    } );
+    auto etree = handle.visit<Handle<ExpressionTree>>( []( auto h ) -> Handle<ExpressionTree> {
+      return { h.content, h.size(), h.is_tag() };
+    } );
+    return fs::exists( repo_ / "data" / base16::encode( Handle<Fix>( vtree ).content ) )
+           || fs::exists( repo_ / "data" / base16::encode( Handle<Fix>( otree ).content ) )
+           || fs::exists( repo_ / "data" / base16::encode( Handle<Fix>( etree ).content ) );
   } catch ( fs::filesystem_error& ) {
     throw RepositoryCorrupt( repo_ );
   }
@@ -238,9 +264,33 @@ bool Repository::contains( Handle<Relation> handle )
   }
 }
 
-std::optional<Handle<AnyTree>> Repository::contains( Handle<AnyTreeRef> )
+std::optional<Handle<AnyTree>> Repository::contains( Handle<AnyTreeRef> handle )
 {
-  throw runtime_error( "Unimplemented" );
+  auto content_hash = base16::encode( handle::fix( handle ).content ).erase( 192 );
+  optional<Handle<Fix>> res {};
+  for ( const auto& dir_entry : fs::directory_iterator( repo_ / "data" ) ) {
+    if ( dir_entry.path().filename().string().find( content_hash ) == 0 ) {
+      res = Handle<Fix>::forge( base16::decode( dir_entry.path().filename().string() ) );
+      break;
+    }
+  }
+
+  auto etree
+    = res.and_then( []( auto h ) -> optional<Handle<AnyTree>> { return handle::extract<ExpressionTree>( h ); } )
+        .or_else( [&]() -> optional<Handle<AnyTree>> {
+          return res.and_then( []( auto h ) { return handle::extract<ObjectTree>( h ); } );
+        } )
+        .or_else( [&]() -> optional<Handle<AnyTree>> {
+          return res.and_then( []( auto h ) { return handle::extract<ValueTree>( h ); } );
+        } )
+        .transform( []( auto h ) -> Handle<ExpressionTree> { return handle::upcast( h ); } );
+
+  return etree.transform( [&]( auto h ) {
+    return handle.visit<Handle<AnyTree>>( overload {
+      [&]( Handle<ValueTreeRef> v ) { return Handle<ValueTree>( h.content, h.size(), v.is_tag() ); },
+      [&]( Handle<ObjectTreeRef> o ) { return Handle<ObjectTree>( h.content, h.size(), o.is_tag() ); },
+    } );
+  } );
 }
 
 #if 0

--- a/src/storage/repository.hh
+++ b/src/storage/repository.hh
@@ -36,6 +36,7 @@ public:
   virtual bool contains( Handle<Named> name ) override;
   virtual bool contains( Handle<AnyTree> name ) override;
   virtual bool contains( Handle<Relation> name ) override;
+  virtual std::optional<Handle<AnyTree>> contains( Handle<AnyTreeRef> name ) override;
 
   bool contains( const std::string_view label ) override;
 

--- a/src/storage/runtimestorage.cc
+++ b/src/storage/runtimestorage.cc
@@ -101,6 +101,9 @@ void RuntimeStorage::visit( Handle<T> handle,
     return;
 
   if constexpr ( Handle<T>::is_fix_sum_type ) {
+    if ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> ) {
+      return;
+    }
     if ( not( std::same_as<T, Thunk> or std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> ) ) {
       std::visit( [&]( const auto x ) { visit( x, visitor, visited ); }, handle.get() );
     }

--- a/src/storage/runtimestorage.hh
+++ b/src/storage/runtimestorage.hh
@@ -126,6 +126,7 @@ public:
   bool contains( Handle<Named> handle );
   bool contains( Handle<AnyTree> handle );
   bool contains( Handle<Relation> handle );
+  std::optional<AnyTree> contains( Handle<AnyTreeRef> handle );
 
   /**
    * Call @p visitor for every Handle in the "minimum repo" of @p root, i.e., the set of Handles which are needed

--- a/src/storage/runtimestorage.hh
+++ b/src/storage/runtimestorage.hh
@@ -7,6 +7,7 @@
 #include <unordered_map>
 
 #include "handle.hh"
+#include "handle_util.hh"
 #include "mutex.hh"
 #include "object.hh"
 
@@ -31,7 +32,7 @@ class RuntimeStorage
 private:
   friend class RuntimeWorker;
   using BlobMap = absl::flat_hash_map<Handle<Named>, BlobData, AbslHash>;
-  using TreeMap = absl::flat_hash_map<Handle<ExpressionTree>, TreeData, AbslHash>;
+  using TreeMap = absl::flat_hash_map<Handle<ExpressionTree>, TreeData, AbslHash, handle::tree_equal>;
   using RelationMap = absl::flat_hash_map<Handle<Fix>, Handle<Object>, AbslHash>;
   using PinMap = absl::flat_hash_map<Handle<Fix>, std::unordered_set<Handle<Fix>>, AbslHash>;
   using LabelMap = absl::flat_hash_map<std::string, Handle<Fix>>;
@@ -126,7 +127,10 @@ public:
   bool contains( Handle<Named> handle );
   bool contains( Handle<AnyTree> handle );
   bool contains( Handle<Relation> handle );
-  std::optional<AnyTree> contains( Handle<AnyTreeRef> handle );
+
+  // return the reffed Handle<AnyTree> if known
+  std::optional<Handle<AnyTree>> contains( Handle<AnyTreeRef> handle );
+  Handle<AnyTreeRef> ref( Handle<AnyTree> tree );
 
   /**
    * Call @p visitor for every Handle in the "minimum repo" of @p root, i.e., the set of Handles which are needed

--- a/src/tests/test-evaluator.cc
+++ b/src/tests/test-evaluator.cc
@@ -75,8 +75,8 @@ private:
   virtual Result<ValueTree> mapEval( Handle<ObjectTree> tree )
   {
     auto objs = storage.get( tree );
-    auto vals = OwnedMutTree::allocate( tree.size() );
-    for ( size_t i = 0; i < tree.size(); i++ ) {
+    auto vals = OwnedMutTree::allocate( objs->size() );
+    for ( size_t i = 0; i < objs->size(); i++ ) {
       vals[i] = evalStrict( objs->at( i ).unwrap<Expression>().unwrap<Object>() ).value();
     }
     return storage.create( std::make_shared<OwnedTree>( std::move( vals ) ) ).unwrap<ValueTree>();
@@ -85,8 +85,8 @@ private:
   virtual Result<ObjectTree> mapReduce( Handle<ExpressionTree> tree )
   {
     auto exprs = storage.get( tree );
-    auto objs = OwnedMutTree::allocate( tree.size() );
-    for ( size_t i = 0; i < tree.size(); i++ ) {
+    auto objs = OwnedMutTree::allocate( exprs->size() );
+    for ( size_t i = 0; i < exprs->size(); i++ ) {
       objs[i] = evaluator_.reduce( exprs->at( i ).unwrap<Expression>() ).value();
     }
     return storage.create_tree<ObjectTree>( std::make_shared<OwnedTree>( std::move( objs ) ) );
@@ -95,8 +95,8 @@ private:
   virtual Result<ValueTree> mapLift( Handle<ValueTree> tree )
   {
     auto vals = storage.get( tree );
-    auto new_vals = OwnedMutTree::allocate( tree.size() );
-    for ( size_t i = 0; i < tree.size(); i++ ) {
+    auto new_vals = OwnedMutTree::allocate( vals->size() );
+    for ( size_t i = 0; i < vals->size(); i++ ) {
       new_vals[i] = evaluator_.lift( vals->at( i ).unwrap<Expression>().unwrap<Object>().unwrap<Value>() ).value();
     }
     return storage.create( std::make_shared<OwnedTree>( std::move( new_vals ) ) ).unwrap<ValueTree>();

--- a/src/tests/test-handle.cc
+++ b/src/tests/test-handle.cc
@@ -62,12 +62,11 @@ void test_int_literal( void )
 void test_ref( void )
 {
   const auto nil = Handle<ValueTree>::nil();
-  const auto ref = nil.into<ValueTreeRef>();
+  const auto ref = nil.into<ValueTreeRef>( 10 );
   CHECK_NE( Handle<Fix>( ref ), Handle<Fix>( nil ) );
   CHECK_EQ( nil.size(), 0 );
   CHECK( not nil.is_local() );
-  CHECK_EQ( ref.unwrap<ValueTree>().size(), 0 );
-  CHECK( not ref.unwrap<ValueTree>().is_local() );
+  CHECK_EQ( handle::size( ref ), 10 );
 }
 
 void test_tag( void )

--- a/src/tests/test-storage.cc
+++ b/src/tests/test-storage.cc
@@ -60,4 +60,10 @@ void test( void )
   CHECK( storage.contains( apply ) );
   CHECK_EQ( storage.get( apply ), target );
   CHECK_EQ( apply.unwrap<ObjectTree>().size(), sizeof( Handle<Fix> ) + virgil.unwrap<Named>().size() );
+
+  auto ref = storage.ref( apply.unwrap<ObjectTree>() );
+  CHECK_EQ( ref.unwrap<ObjectTreeRef>().size(), 1 );
+  auto unref = storage.contains( ref );
+  CHECK( unref.has_value() );
+  CHECK_EQ( unref.value().unwrap<ObjectTree>(), apply.unwrap<ObjectTree>() );
 }

--- a/src/tests/test-storage.cc
+++ b/src/tests/test-storage.cc
@@ -59,4 +59,5 @@ void test( void )
   storage.create( target, apply );
   CHECK( storage.contains( apply ) );
   CHECK_EQ( storage.get( apply ), target );
+  CHECK_EQ( apply.unwrap<ObjectTree>().size(), sizeof( Handle<Fix> ) + virgil.unwrap<Named>().size() );
 }


### PR DESCRIPTION
* `load( AnyTreeRef )` loads the TreeData
* `Handle<Tree>` contains the recursively summed size of data and `Handle<TreeRef>` contains the number of entries