### PR TITLE
Make get/put Objects across Remotes recursive

### DIFF
--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -111,10 +111,10 @@ void Remote::put( Handle<AnyTree> name, TreeData data )
 
 void Remote::put( Handle<Relation> name, Handle<Object> data )
 {
-  VLOG( 2 ) << "Putting result to remote " << name;
   unique_lock lock( mutex_ );
   if ( reply_to_.contains( name ) ) {
     if ( !contains( name ) ) {
+      VLOG( 2 ) << "Putting result to remote " << name;
       ResultPayload payload { .task = name, .result = data };
       msg_q_.enqueue( make_pair( index_, move( payload ) ) );
     }

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -89,6 +89,16 @@ optional<TreeData> Remote::get( Handle<AnyTree> name )
 
 optional<Handle<Object>> Remote::get( Handle<Relation> name )
 {
+  if ( !contains( name ) ) {
+    parent_.value().get().visit( job::get_root( name ), [&]( Handle<AnyDataType> h ) {
+      h.visit<void>( overload { []( Handle<Literal> ) {},
+                                []( Handle<Relation> ) {},
+                                [&]( auto x ) {
+                                  msg_q_.enqueue(
+                                    make_pair( index_, make_pair( x, parent_.value().get().get( x ).value() ) ) );
+                                } } );
+    } );
+  }
   RunPayload payload { .task = name };
   msg_q_.enqueue( make_pair( index_, move( payload ) ) );
 
@@ -102,10 +112,17 @@ void Remote::put( Handle<Named> name, BlobData data )
   }
 }
 
-void Remote::put( Handle<AnyTree> name, TreeData data )
+void Remote::put( Handle<AnyTree> name, TreeData )
 {
   if ( !contains( name ) ) {
-    msg_q_.enqueue( make_pair( index_, make_pair( name, data ) ) );
+    parent_.value().get().visit( handle::upcast( name ), [&]( Handle<AnyDataType> h ) {
+      h.visit<void>( overload { []( Handle<Literal> ) {},
+                                []( Handle<Relation> ) {},
+                                [&]( auto x ) {
+                                  msg_q_.enqueue(
+                                    make_pair( index_, make_pair( x, parent_.value().get().get( x ).value() ) ) );
+                                } } );
+    } );
   }
 }
 
@@ -114,6 +131,16 @@ void Remote::put( Handle<Relation> name, Handle<Object> data )
   unique_lock lock( mutex_ );
   if ( reply_to_.contains( name ) ) {
     if ( !contains( name ) ) {
+      // Send the result of the relation first
+      parent_.value().get().visit( data, [&]( Handle<AnyDataType> h ) {
+        h.visit<void>( overload { []( Handle<Literal> ) {},
+                                  []( Handle<Relation> ) {},
+                                  [&]( auto x ) {
+                                    msg_q_.enqueue(
+                                      make_pair( index_, make_pair( x, parent_.value().get().get( x ).value() ) ) );
+                                  } } );
+      } );
+
       VLOG( 2 ) << "Putting result to remote " << name;
       ResultPayload payload { .task = name, .result = data };
       msg_q_.enqueue( make_pair( index_, move( payload ) ) );
@@ -216,12 +243,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
 
       auto res = parent.get( payload.task );
       if ( res.has_value() ) {
-        bool need_send = erase_reply_to( task );
-
-        if ( need_send ) {
-          ResultPayload payload { .task = task, .result = *res };
-          push_message( OutgoingMessage::to_message( move( payload ) ) );
-        }
+        this->put( payload.task, res.value() );
       }
       break;
     }
@@ -249,7 +271,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
       auto payload = parse<RequestTreePayload>( std::get<string>( msg.payload() ) );
       auto tree = parent.get( payload.handle );
       if ( tree )
-        send_tree( *tree );
+        this->put( payload.handle, tree.value() );
       break;
     }
 
@@ -257,7 +279,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
       auto payload = parse<RequestBlobPayload>( std::get<string>( msg.payload() ) );
       auto blob = parent.get( payload.handle );
       if ( blob )
-        send_blob( blob.value() );
+        this->put( payload.handle, blob.value() );
       break;
     }
 

--- a/src/runtime/relater.cc
+++ b/src/runtime/relater.cc
@@ -62,6 +62,8 @@ Relater::Relater( size_t threads, optional<shared_ptr<Runner>> runner, optional<
 
 Relater::Result<Fix> Relater::load( Handle<AnyDataType> handle )
 {
+  auto graph = graph_.write();
+
   auto contained = handle.visit<bool>(
     overload { [&]( Handle<Literal> ) { return true; }, [&]( auto h ) { return storage_.contains( h ); } } );
 
@@ -71,10 +73,10 @@ Relater::Result<Fix> Relater::load( Handle<AnyDataType> handle )
     handle.visit<void>( overload {
       []( Handle<Literal> ) { throw std::runtime_error( "Unreachable" ); },
       [&]( Handle<AnyTree> t ) {
-        t.visit<void>( [&]( auto h ) { graph_.write()->add_dependency( current_.value(), h ); } );
+        t.visit<void>( [&]( auto h ) { graph->add_dependency( current_.value(), h ); } );
       },
-      [&]( Handle<Named> n ) { graph_.write()->add_dependency( current_.value(), n ); },
-      [&]( Handle<Relation> r ) { graph_.write()->add_dependency( current_.value(), r ); },
+      [&]( Handle<Named> n ) { graph->add_dependency( current_.value(), n ); },
+      [&]( Handle<Relation> r ) { graph->add_dependency( current_.value(), r ); },
     } );
     works_.push_back( handle );
     return {};
@@ -127,8 +129,13 @@ Relater::Result<Object> Relater::apply( Handle<ObjectTree> combination )
     return get( apply );
   }
 
-  if ( apply != current_ ) {
-    graph_.write()->add_dependency( current_.value(), apply );
+  {
+    auto graph = graph_.write();
+    if ( apply != current_ and !storage_.contains( apply ) ) {
+      graph->add_dependency( current_.value(), apply );
+    } else if ( storage_.contains( apply ) ) {
+      return storage_.get( apply );
+    }
   }
   works_.push_back( Handle<Apply>( combination ) );
   return {};
@@ -166,8 +173,12 @@ Relater::Result<Value> Relater::evalStrict( Handle<Object> expression )
   if ( result.has_value() ) {
     this->put( goal, result.value() );
   } else {
-    if ( prev_current.has_value() and prev_current.value() != Handle<Relation>( goal ) ) {
-      graph_.write()->add_dependency( prev_current.value(), goal );
+    auto graph = graph_.write();
+    if ( prev_current.has_value() and prev_current.value() != Handle<Relation>( goal )
+         and !storage_.contains( goal ) ) {
+      graph->add_dependency( prev_current.value(), goal );
+    } else if ( storage_.contains( goal ) ) {
+      return storage_.get( goal ).unwrap<Value>();
     }
   }
 
@@ -343,13 +354,6 @@ void Relater::put( Handle<Named> name, BlobData data )
     for ( auto x : unblocked ) {
       local_->get( x );
     }
-    // for ( auto& remote : remotes_.read().get() ) {
-    //   VLOG( 1 ) << "Putting to relater name to remote " << name;
-    //   auto locked = remote.lock();
-    //   if ( locked ) {
-    //     locked->put( name, data );
-    //   }
-    // }
   }
 }
 void Relater::put( Handle<AnyTree> name, TreeData data )
@@ -364,13 +368,6 @@ void Relater::put( Handle<AnyTree> name, TreeData data )
     for ( auto x : unblocked ) {
       local_->get( x );
     }
-    // for ( auto& remote : remotes_.read().get() ) {
-    //   VLOG( 1 ) << "Putting to relater name to remote " << name;
-    //   auto locked = remote.lock();
-    //   if ( locked ) {
-    //     locked->put( name, data );
-    //   }
-    // }
   }
 }
 void Relater::put( Handle<Relation> name, Handle<Object> data )

--- a/src/runtime/relater.cc
+++ b/src/runtime/relater.cc
@@ -199,7 +199,7 @@ Relater::Result<ValueTree> Relater::mapEval( Handle<ObjectTree> tree )
   for ( size_t i = 0; i < data->size(); i++ ) {
     auto x = data->at( i );
     auto obj = x.unwrap<Expression>().unwrap<Object>();
-    values[i] = evaluator_.evalStrict( obj ).value();
+    values[i] = evalStrict( obj ).value();
   }
 
   if ( tree.is_tag() ) {

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -85,44 +85,6 @@ public:
   }
 
   template<FixType T>
-  void visit( Handle<T> handle,
-              std::function<void( Handle<AnyDataType> )> visitor,
-              std::unordered_set<Handle<Fix>> visited = {} )
-  {
-    if ( visited.contains( handle ) )
-      return;
-    if constexpr ( std::same_as<T, Literal> )
-      return;
-
-    if constexpr ( Handle<T>::is_fix_sum_type ) {
-      if constexpr ( std::same_as<T, Encode> ) {
-        Handle<Thunk> thunk
-          = handle.template visit<Handle<Thunk>>( []( auto s ) { return s.template unwrap<Thunk>(); } );
-        thunk.visit<void>(
-          overload { [&]( Handle<Application> a ) { visit( a.unwrap<ExpressionTree>(), visitor, visited ); },
-                     []( auto ) {} } );
-      }
-
-      if constexpr ( not( std::same_as<T, Thunk> or std::same_as<T, Encode> ) )
-        std::visit( [&]( const auto x ) { visit( x, visitor, visited ); }, handle.get() );
-
-    } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> ) {
-      return;
-    } else {
-      if constexpr ( FixTreeType<T> ) {
-        // Having the handle means that the data presents in storage
-        auto tree = get( handle );
-        for ( const auto& element : tree.value()->span() ) {
-          visit( element, visitor, visited );
-        }
-      }
-      VLOG( 3 ) << "visiting " << handle;
-      visitor( handle );
-      visited.insert( handle );
-    }
-  }
-
-  template<FixType T>
   void visit_full( Handle<T> handle,
                    std::function<void( Handle<AnyDataType> )> visitor,
                    std::unordered_set<Handle<Fix>> visited = {} )

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -116,7 +116,7 @@ public:
           visit( element, visitor, visited );
         }
       }
-      VLOG( 2 ) << "visiting " << handle;
+      VLOG( 3 ) << "visiting " << handle;
       visitor( handle );
       visited.insert( handle );
     }
@@ -142,7 +142,7 @@ public:
                      []( Handle<Eval> h ) { return h.unwrap<Object>(); } } );
         std::visit( [&]( const auto x ) { visit_full( x, visitor, visited ); }, lhs.get() );
 
-        VLOG( 2 ) << "visiting " << handle;
+        VLOG( 3 ) << "visiting " << handle;
         visitor( handle );
         visited.insert( handle );
       }
@@ -156,7 +156,7 @@ public:
           visit_full( element, visitor, visited );
         }
       }
-      VLOG( 2 ) << "visiting " << handle;
+      VLOG( 3 ) << "visiting " << handle;
       visitor( handle );
       visited.insert( handle );
     }
@@ -180,7 +180,7 @@ public:
     } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> ) {
       return;
     } else {
-      VLOG( 2 ) << "visiting " << handle;
+      VLOG( 3 ) << "visiting " << handle;
       auto res = visitor( handle );
       visited.insert( handle );
 

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -138,6 +138,45 @@ public:
       visited.insert( handle );
     }
   }
+
+  // Visit from a root (include Handle<Strict>( Handle<Application>( Handle<ExrpessionTree> ) ) )
+  template<FixType T>
+  void visit( Handle<T> handle,
+              std::function<void( Handle<AnyDataType> )> visitor,
+              std::unordered_set<Handle<Fix>> visited = {} )
+  {
+    if ( visited.contains( handle ) )
+      return;
+    if constexpr ( std::same_as<T, Literal> )
+      return;
+
+    if constexpr ( Handle<T>::is_fix_sum_type ) {
+      if constexpr ( std::same_as<T, Encode> ) {
+        Handle<Thunk> thunk
+          = handle.template visit<Handle<Thunk>>( []( auto s ) { return s.template unwrap<Thunk>(); } );
+        thunk.visit<void>(
+          overload { [&]( Handle<Application> a ) { visit( a.unwrap<ExpressionTree>(), visitor, visited ); },
+                     []( auto ) {} } );
+      }
+
+      if constexpr ( not( std::same_as<T, Thunk> or std::same_as<T, Encode> ) )
+        std::visit( [&]( const auto x ) { visit( x, visitor, visited ); }, handle.get() );
+
+    } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> ) {
+      return;
+    } else {
+      if constexpr ( FixTreeType<T> ) {
+        // Having the handle means that the data presents in storage
+        auto tree = get( handle );
+        for ( const auto& element : tree.value()->span() ) {
+          visit( element, visitor, visited );
+        }
+      }
+      VLOG( 3 ) << "visiting " << handle;
+      visitor( handle );
+      visited.insert( handle );
+    }
+  }
 };
 
 class MultiWorkerRuntime : public IRuntime

--- a/src/storage/runtimestorage.cc
+++ b/src/storage/runtimestorage.cc
@@ -62,7 +62,7 @@ template Handle<Tree<Expression>> RuntimeStorage::create_tree( TreeData, std::op
 
 BlobData RuntimeStorage::get( Handle<Named> handle )
 {
-  VLOG( 2 ) << "get " << handle;
+  VLOG( 3 ) << "get " << handle;
   auto blobs = blobs_.read();
   if ( blobs->contains( handle ) ) {
     return blobs->at( handle );
@@ -72,7 +72,7 @@ BlobData RuntimeStorage::get( Handle<Named> handle )
 
 TreeData RuntimeStorage::get( Handle<AnyTree> handle )
 {
-  VLOG( 2 ) << "get " << handle;
+  VLOG( 3 ) << "get " << handle;
   auto trees = trees_.read();
   auto generic = handle::upcast( handle ).untag();
   if ( trees->contains( generic ) ) {
@@ -118,7 +118,7 @@ void RuntimeStorage::visit( Handle<T> handle,
         visit( element, visitor, visited );
       }
     }
-    VLOG( 2 ) << "visiting " << handle;
+    VLOG( 3 ) << "visiting " << handle;
     visitor( handle );
     visited.insert( handle );
   }
@@ -148,7 +148,7 @@ void RuntimeStorage::visit_full(
         visit_full( element, visitor, pin_visitor, visited );
       }
     }
-    VLOG( 2 ) << "full-visiting " << handle;
+    VLOG( 3 ) << "full-visiting " << handle;
     visitor( handle );
     visited.insert( handle );
   }

--- a/src/tester/tester-utils.cc
+++ b/src/tester/tester-utils.cc
@@ -117,7 +117,13 @@ Handle<Fix> parse_args( IRuntime& rt, std::span<char*>& args )
 
   if ( str.starts_with( "compile:" ) ) {
     args = args.subspan( 1 );
+    bool prev_consumed = consumed;
+
+    consumed = true;
     auto name = parse_args( rt, args );
+
+    consumed = prev_consumed;
+
     if ( consumed ) {
       return Handle<Strict>( make_compile( rt, name ) );
     } else {


### PR DESCRIPTION
* `Remote::put( Handle<AnyTree>, Data )` recursively puts the whole Tree to the other end
* `Remote::get( Handle<Relation> )` puts the required data for progressing the relation to the other end before sends the `Run` message
* Fix a race condition in accessing `DependencyGraph`