### PR TITLE
Optimizations

### DIFF
--- a/src/runtime/relater.cc
+++ b/src/runtime/relater.cc
@@ -194,87 +194,108 @@ Relater::Result<Object> Relater::evalShallow( Handle<Object> expression )
 Relater::Result<ValueTree> Relater::mapEval( Handle<ObjectTree> tree )
 {
   bool ready = true;
+  bool toreplace = false;
   auto data = storage_.get( tree );
   for ( const auto& x : data->span() ) {
     auto obj = x.unwrap<Expression>().unwrap<Object>();
     auto result = evalStrict( obj );
     if ( not result ) {
       ready = false;
+    } else if ( !toreplace && Handle<Object>( result.value() ) != obj ) {
+      toreplace = true;
     }
   }
   if ( not ready ) {
     return {};
   }
 
-  auto values = OwnedMutTree::allocate( data->size() );
-  for ( size_t i = 0; i < data->size(); i++ ) {
-    auto x = data->at( i );
-    auto obj = x.unwrap<Expression>().unwrap<Object>();
-    values[i] = evalStrict( obj ).value();
-  }
+  if ( toreplace ) {
+    auto values = OwnedMutTree::allocate( data->size() );
+    for ( size_t i = 0; i < data->size(); i++ ) {
+      auto x = data->at( i );
+      auto obj = x.unwrap<Expression>().unwrap<Object>();
+      values[i] = evalStrict( obj ).value();
+    }
 
-  if ( tree.is_tag() ) {
-    return storage_.create( std::make_shared<OwnedTree>( std::move( values ) ) ).unwrap<ValueTree>().tag();
+    if ( tree.is_tag() ) {
+      return storage_.create( std::make_shared<OwnedTree>( std::move( values ) ) ).unwrap<ValueTree>().tag();
+    } else {
+      return storage_.create( std::make_shared<OwnedTree>( std::move( values ) ) ).unwrap<ValueTree>();
+    }
   } else {
-    return storage_.create( std::make_shared<OwnedTree>( std::move( values ) ) ).unwrap<ValueTree>();
+    return Handle<ValueTree>( tree.content, tree.size(), tree.is_tag() );
   }
 }
 
 Relater::Result<ObjectTree> Relater::mapReduce( Handle<ExpressionTree> tree )
 {
   bool ready = true;
+  bool toreplace = false;
   TreeData data = storage_.get( tree );
   for ( const auto& x : data->span() ) {
     auto exp = x.unwrap<Expression>();
     auto result = evaluator_.reduce( exp );
     if ( not result ) {
       ready = false;
+    } else if ( !toreplace && x != Handle<Fix>( Handle<Expression>( result.value() ) ) ) {
+      toreplace = true;
     }
   }
   if ( not ready ) {
     return {};
   }
 
-  auto objs = OwnedMutTree::allocate( data->size() );
-  for ( size_t i = 0; i < data->size(); i++ ) {
-    auto exp = data->at( i ).unwrap<Expression>();
-    objs[i] = evaluator_.reduce( exp ).value();
-  }
+  if ( toreplace ) {
+    auto objs = OwnedMutTree::allocate( data->size() );
+    for ( size_t i = 0; i < data->size(); i++ ) {
+      auto exp = data->at( i ).unwrap<Expression>();
+      objs[i] = evaluator_.reduce( exp ).value();
+    }
 
-  if ( tree.is_tag() ) {
-    return handle::tree_unwrap<ObjectTree>( storage_.create( std::make_shared<OwnedTree>( std::move( objs ) ) ) )
-      .tag();
+    if ( tree.is_tag() ) {
+      return handle::tree_unwrap<ObjectTree>( storage_.create( std::make_shared<OwnedTree>( std::move( objs ) ) ) )
+        .tag();
+    } else {
+      return handle::tree_unwrap<ObjectTree>( storage_.create( std::make_shared<OwnedTree>( std::move( objs ) ) ) );
+    }
   } else {
-    return handle::tree_unwrap<ObjectTree>( storage_.create( std::make_shared<OwnedTree>( std::move( objs ) ) ) );
+    return Handle<ObjectTree>( tree.content, tree.size(), tree.is_tag() );
   }
 }
 
 Relater::Result<ValueTree> Relater::mapLift( Handle<ValueTree> tree )
 {
   bool ready = true;
+  bool toreplace = false;
   auto data = storage_.get( tree );
   for ( const auto& x : data->span() ) {
     auto val = x.unwrap<Expression>().unwrap<Object>().unwrap<Value>();
     auto result = evaluator_.lift( val );
     if ( not result ) {
       ready = false;
+    } else if ( !toreplace && result.value() != val ) {
+      toreplace = true;
     }
   }
   if ( not ready ) {
     return {};
   }
 
-  auto vals = OwnedMutTree::allocate( data->size() );
-  for ( size_t i = 0; i < data->size(); i++ ) {
-    auto x = data->at( i );
-    auto exp = x.unwrap<Expression>();
-    vals[i] = evaluator_.reduce( exp ).value();
-  }
+  if ( toreplace ) {
+    auto vals = OwnedMutTree::allocate( data->size() );
+    for ( size_t i = 0; i < data->size(); i++ ) {
+      auto x = data->at( i );
+      auto val = x.unwrap<Expression>().unwrap<Object>().unwrap<Value>();
+      vals[i] = evaluator_.lift( val ).value();
+    }
 
-  if ( tree.is_tag() ) {
-    return storage_.create( std::make_shared<OwnedTree>( std::move( vals ) ) ).unwrap<ValueTree>().tag();
+    if ( tree.is_tag() ) {
+      return storage_.create( std::make_shared<OwnedTree>( std::move( vals ) ) ).unwrap<ValueTree>().tag();
+    } else {
+      return storage_.create( std::make_shared<OwnedTree>( std::move( vals ) ) ).unwrap<ValueTree>();
+    }
   } else {
-    return storage_.create( std::make_shared<OwnedTree>( std::move( vals ) ) ).unwrap<ValueTree>();
+    return tree;
   }
 }
 

--- a/src/runtime/runtimes.cc
+++ b/src/runtime/runtimes.cc
@@ -27,7 +27,7 @@ Handle<Value> ReadWriteRT::execute( Handle<Relation> x )
   relater_.visit_full( x, [this]( Handle<AnyDataType> h ) {
     h.visit<void>( overload { []( Handle<Literal> ) {},
                               [&]( auto handle ) {
-                                auto repo = relater_.get_repository();
+                                auto& repo = relater_.get_repository();
                                 if ( not repo.contains( handle ) )
                                   repo.put( handle, relater_.get( handle ).value() );
                               } } );

--- a/src/storage/handle_util.hh
+++ b/src/storage/handle_util.hh
@@ -71,6 +71,15 @@ struct tree_equal
 #endif
   }
 };
+
+struct any_tree_equal
+{
+  tree_equal te;
+  constexpr bool operator()( const Handle<AnyTree>& lhs, const Handle<AnyTree>& rhs ) const
+  {
+    return te( handle::upcast( lhs ), handle::upcast( rhs ) );
+  }
+};
 }
 
 namespace job {

--- a/src/storage/repository.cc
+++ b/src/storage/repository.cc
@@ -1,6 +1,5 @@
 #include <filesystem>
 #include <glog/logging.h>
-#include <iostream>
 
 #include "base16.hh"
 #include "handle_post.hh"
@@ -14,6 +13,17 @@ Repository::Repository( std::filesystem::path directory )
   : repo_( find( directory ) )
 {
   VLOG( 1 ) << "using repository " << repo_;
+
+  for ( auto h : data() ) {
+    h.visit<void>( overload { []( Handle<Literal> ) {},
+                              [&]( Handle<Named> n ) { blobs_.write()->insert( n ); },
+                              [&]( Handle<AnyTree> t ) { trees_.write()->insert( t ); },
+                              []( Handle<Relation> ) {} } );
+  }
+
+  for ( auto r : relations() ) {
+    relations_.write()->insert( r );
+  }
 }
 
 std::filesystem::path Repository::find( std::filesystem::path directory )
@@ -29,18 +39,33 @@ std::filesystem::path Repository::find( std::filesystem::path directory )
   return current_directory / ".fix";
 }
 
-std::unordered_set<Handle<Fix>> Repository::data() const
+std::unordered_set<Handle<AnyDataType>> Repository::data() const
 {
   try {
-    std::unordered_set<Handle<Fix>> result;
+    std::unordered_set<Handle<AnyDataType>> result;
     for ( const auto& datum : fs::directory_iterator( repo_ / "data" ) ) {
-      result.insert( Handle<Fix>::forge( base16::decode( datum.path().filename().string() ) ) );
+      result.insert( handle::data( Handle<Fix>::forge( base16::decode( datum.path().filename().string() ) ) ) );
     }
     return result;
   } catch ( std::filesystem::filesystem_error& ) {
     throw RepositoryCorrupt( repo_ );
   }
 }
+
+std::unordered_set<Handle<Relation>> Repository::relations() const
+{
+  try {
+    std::unordered_set<Handle<Relation>> result;
+    for ( const auto& relation : fs::directory_iterator( repo_ / "relations" ) ) {
+      result.insert(
+        Handle<Fix>::forge( base16::decode( relation.path().filename().string() ) ).unwrap<Relation>() );
+    }
+    return result;
+  } catch ( std::filesystem::filesystem_error& ) {
+    throw RepositoryCorrupt( repo_ );
+  }
+}
+
 std::unordered_set<std::string> Repository::labels() const
 {
   try {
@@ -134,6 +159,7 @@ void Repository::put( Handle<Named> name, BlobData data )
     auto path = repo_ / "data" / base16::encode( fix.content );
     if ( fs::exists( path ) )
       return;
+    blobs_.write()->insert( name );
     data->to_file( path );
   } catch ( std::filesystem::filesystem_error& ) {
     throw RepositoryCorrupt( repo_ );
@@ -149,6 +175,7 @@ void Repository::put( Handle<AnyTree> name, TreeData data )
     auto path = repo_ / "data" / base16::encode( fix.content );
     if ( fs::exists( path ) )
       return;
+    trees_.write()->insert( name );
     data->to_file( path );
   } catch ( std::filesystem::filesystem_error& ) {
     throw RepositoryCorrupt( repo_ );
@@ -166,6 +193,7 @@ void Repository::put( Handle<Relation> relation, Handle<Object> target )
     if ( fs::exists( path ) )
       return;
     VLOG( 1 ) << "linking to " << target.content;
+    relations_.write()->insert( relation );
     fs::create_symlink( "../data/" + base16::encode( target.content ), path );
   } catch ( std::filesystem::filesystem_error& ) {
     throw RepositoryCorrupt( repo_ );
@@ -228,68 +256,38 @@ void Repository::pin( Handle<Fix> src, const std::unordered_set<Handle<Fix>>& ds
 
 bool Repository::contains( Handle<Named> handle )
 {
-  try {
-    return fs::exists( repo_ / "data" / base16::encode( Handle<Fix>( handle ).content ) );
-  } catch ( fs::filesystem_error& ) {
-    throw RepositoryCorrupt( repo_ );
-  }
+  return blobs_.read()->contains( handle );
 }
 
 bool Repository::contains( Handle<AnyTree> handle )
 {
-  try {
-    auto vtree = handle.visit<Handle<ValueTree>>( []( auto h ) -> Handle<ValueTree> {
-      return { h.content, h.size(), h.is_tag() };
-    } );
-    auto otree = handle.visit<Handle<ObjectTree>>( []( auto h ) -> Handle<ObjectTree> {
-      return { h.content, h.size(), h.is_tag() };
-    } );
-    auto etree = handle.visit<Handle<ExpressionTree>>( []( auto h ) -> Handle<ExpressionTree> {
-      return { h.content, h.size(), h.is_tag() };
-    } );
-    return fs::exists( repo_ / "data" / base16::encode( Handle<Fix>( vtree ).content ) )
-           || fs::exists( repo_ / "data" / base16::encode( Handle<Fix>( otree ).content ) )
-           || fs::exists( repo_ / "data" / base16::encode( Handle<Fix>( etree ).content ) );
-  } catch ( fs::filesystem_error& ) {
-    throw RepositoryCorrupt( repo_ );
-  }
+  return trees_.read()->contains( handle );
 }
 
 bool Repository::contains( Handle<Relation> handle )
 {
-  try {
-    return fs::is_symlink( repo_ / "relations" / base16::encode( Handle<Fix>( handle ).content ) );
-  } catch ( fs::filesystem_error& ) {
-    throw RepositoryCorrupt( repo_ );
-  }
+  return relations_.read()->contains( handle );
 }
 
 std::optional<Handle<AnyTree>> Repository::contains( Handle<AnyTreeRef> handle )
 {
-  auto content_hash = base16::encode( handle::fix( handle ).content ).erase( 192 );
-  optional<Handle<Fix>> res {};
-  for ( const auto& dir_entry : fs::directory_iterator( repo_ / "data" ) ) {
-    if ( dir_entry.path().filename().string().find( content_hash ) == 0 ) {
-      res = Handle<Fix>::forge( base16::decode( dir_entry.path().filename().string() ) );
-      break;
-    }
+  auto tmp_tree = handle.visit<Handle<AnyTree>>(
+    overload { []( Handle<ValueTreeRef> r ) { return Handle<ValueTree>( r.content, 0 ); },
+               []( Handle<ObjectTreeRef> r ) { return Handle<ObjectTree>( r.content, 0 ); } } );
+
+  auto trees = trees_.read();
+  auto entry = trees->find( tmp_tree );
+
+  if ( entry == trees->end() ) {
+    return {};
   }
 
-  auto etree
-    = res.and_then( []( auto h ) -> optional<Handle<AnyTree>> { return handle::extract<ExpressionTree>( h ); } )
-        .or_else( [&]() -> optional<Handle<AnyTree>> {
-          return res.and_then( []( auto h ) { return handle::extract<ObjectTree>( h ); } );
-        } )
-        .or_else( [&]() -> optional<Handle<AnyTree>> {
-          return res.and_then( []( auto h ) { return handle::extract<ValueTree>( h ); } );
-        } )
-        .transform( []( auto h ) -> Handle<ExpressionTree> { return handle::upcast( h ); } );
+  auto hash = std::visit( []( auto e ) { return e.content; }, entry->get() );
+  auto size = std::visit( []( auto e ) { return e.size(); }, entry->get() );
 
-  return etree.transform( [&]( auto h ) {
-    return handle.visit<Handle<AnyTree>>( overload {
-      [&]( Handle<ValueTreeRef> v ) { return Handle<ValueTree>( h.content, h.size(), v.is_tag() ); },
-      [&]( Handle<ObjectTreeRef> o ) { return Handle<ObjectTree>( h.content, h.size(), o.is_tag() ); },
-    } );
+  return handle.visit<Handle<AnyTree>>( overload {
+    [&]( Handle<ValueTreeRef> v ) { return Handle<ValueTree>( hash, size, v.is_tag() ); },
+    [&]( Handle<ObjectTreeRef> o ) { return Handle<ObjectTree>( hash, size, o.is_tag() ); },
   } );
 }
 
@@ -394,7 +392,7 @@ Handle<Fix> Repository::lookup( const std::string_view ref )
     if ( name.rfind( ref, 0 ) == 0 ) {
       if ( candidate )
         throw AmbiguousReference( ref );
-      candidate = handle;
+      candidate = handle::fix( handle );
     }
   }
   if ( candidate )

--- a/src/storage/repository.hh
+++ b/src/storage/repository.hh
@@ -1,21 +1,29 @@
 #pragma once
+#include <absl/container/flat_hash_set.h>
 #include <filesystem>
 #include <unordered_map>
 #include <unordered_set>
 
 #include "handle.hh"
 #include "interface.hh"
+#include "mutex.hh"
 #include "object.hh"
+#include "runtimestorage.hh"
 
 class Repository : public IRuntime
 {
   std::filesystem::path repo_;
 
+  SharedMutex<absl::flat_hash_set<Handle<Named>, AbslHash>> blobs_ {};
+  SharedMutex<absl::flat_hash_set<Handle<AnyTree>, AbslHash, handle::any_tree_equal>> trees_ {};
+  SharedMutex<absl::flat_hash_set<Handle<Relation>, AbslHash>> relations_ {};
+
 public:
   Repository( std::filesystem::path directory = std::filesystem::current_path() );
   static std::filesystem::path find( std::filesystem::path directory = std::filesystem::current_path() );
 
-  std::unordered_set<Handle<Fix>> data() const;
+  std::unordered_set<Handle<AnyDataType>> data() const;
+  std::unordered_set<Handle<Relation>> relations() const;
   std::unordered_set<std::string> labels() const;
   std::unordered_map<Handle<Fix>, std::unordered_set<Handle<Fix>>> pins() const;
 


### PR DESCRIPTION
This PR includes 2 optimizations to bring down the lightweight virtualization benchmark to its current number:
* `Relater` only allocates and inserts a new tree if necessary, otherwise it directly returns the handle with the correct type.
* `Repository` stores the list of datas and relations to avoid checking path existence in `contains()`.