### PR TITLE
Send Repository::data() as part of INFO. Add Wikipedia-related code.

### DIFF
--- a/applications/count-words/count_words.c
+++ b/applications/count-words/count_words.c
@@ -4,17 +4,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-int compare( const void* a, const void* b )
+void out( const char* s )
 {
-  const char* s = *(const char**)a;
-  const char* t = *(const char**)b;
-  return strcmp( s, t );
+  fixpoint_unsafe_io( s, strlen( s ) );
 }
 
-/**
- * @brief Counts the words in the input blob.
- * @return externref  A CSV file as a blob.
- */
 __attribute__( ( export_name( "_fixpoint_apply" ) ) ) externref _fixpoint_apply( externref combination )
 
 {
@@ -30,67 +24,18 @@ __attribute__( ( export_name( "_fixpoint_apply" ) ) ) externref _fixpoint_apply(
   size_t size = get_length( input );
   char* file = (char*)malloc( size );
   ro_mem_0_to_program_mem( file, 0, size );
-  const char* delim = " \n\t,.!?;";
 
-  size_t num = 1;
-  for ( size_t i = 0; i < size; i++ )
-    num += strchr( delim, file[i] ) ? 1 : 0;
+  uint64_t counts[256];
+  memset( counts, 0, sizeof( counts ) );
 
-  char** strings = (char**)malloc( sizeof( char* ) * num );
-
-  size_t N = 0;
-  char* p = strtok( file, delim );
-  do {
-    strings[N] = p;
-    N++;
-  } while ( ( p = strtok( NULL, delim ) ) );
-
-  qsort( (void*)strings, N, sizeof( char* ), compare );
-
-  char** keys = (char**)malloc( sizeof( char* ) * N );
-  size_t* values = (size_t*)malloc( sizeof( size_t ) * N );
-  size_t i = 0;
-
-  size_t char_count = 0;
-  for ( size_t j = 0; j < N; ) {
-    char* current = strings[j];
-    char_count += strlen( current );
-    size_t k = j;
-    while ( k < N && !strcmp( strings[k], current ) )
-      k++;
-    size_t n = k - j;
-    keys[i] = current;
-    values[i] = n;
-    i++;
-    j = k;
-  }
-  size_t n = i;
-
-  // number of characters in words, plus ",0x%08x\n" on every line
-  size_t output_bytes = char_count + n * ( 1 + 10 + 1 );
-
-  char* output = (char*)malloc( output_bytes );
-
-  char* cursor = output;
-  for ( size_t i = 0; i < n; i++ ) {
-    size_t m = strlen( keys[i] );
-    strcpy( cursor, keys[i] );
-    cursor += m;
-    *cursor++ = ',';
-    *cursor++ = '0';
-    *cursor++ = 'x';
-    for ( size_t j = 0; j < 32; j += 4 ) {
-      size_t shift = ( 28 - j );
-      int x = values[i] >> shift;
-      char y = "0123456789abcdef"[x];
-      *cursor++ = y;
-    }
-    *cursor++ = '\n';
+  for ( size_t i = 0; i < size; i++ ) {
+    counts[file[i]]++;
   }
 
-  size_t pages = output_bytes / 4096 + 1;
-  grow_rw_mem_0_pages( pages );
-  program_mem_to_rw_mem_0( 0, output, output_bytes );
+  if ( grow_rw_mem_0_pages( 1 ) == -1 ) {
+    out( "count words: grow error" );
+  }
+  program_mem_to_rw_mem_0( 0, counts, sizeof( counts ) );
 
-  return create_blob_rw_mem_0( output_bytes );
+  return create_blob_rw_mem_0( sizeof( counts ) );
 }

--- a/applications/count-words/merge_counts.c
+++ b/applications/count-words/merge_counts.c
@@ -4,24 +4,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-char decode( char x )
+void out( const char* s )
 {
-  if ( x >= '0' && x <= '9' ) {
-    return x - '0';
-  }
-  if ( x >= 'a' && x <= 'f' ) {
-    return x - 'a';
-  }
-  if ( x >= 'A' && x <= 'F' ) {
-    return x - 'A';
-  }
-  return 0;
+  fixpoint_unsafe_io( s, strlen( s ) );
 }
 
-/**
- * @brief Merges two wordcount CSVs into a single larger one.
- * @return externref  A wordcount CSV.
- */
 __attribute__( ( export_name( "_fixpoint_apply" ) ) ) externref _fixpoint_apply( externref combination )
 {
   externref nil = create_blob_rw_mem_0( 0 );
@@ -38,141 +25,20 @@ __attribute__( ( export_name( "_fixpoint_apply" ) ) ) externref _fixpoint_apply(
   size_t sX = get_length( X );
   size_t sY = get_length( Y );
 
-  char* fX = (char*)malloc( sX );
-  char* fY = (char*)malloc( sY );
+  uint64_t fX[256];
+  uint64_t fY[256];
   ro_mem_0_to_program_mem( fX, 0, sX );
   ro_mem_1_to_program_mem( fY, 0, sY );
 
-  size_t nX = 0;
-  size_t nY = 0;
-
-  for ( size_t i = 0; i < sX; i++ )
-    nX += fX[i] == '\n';
-  for ( size_t i = 0; i < sY; i++ )
-    nY += fY[i] == '\n';
-
-  char** keysX = (char**)malloc( sizeof( char* ) * nX );
-  char** valsXstr = (char**)malloc( sizeof( char* ) * nX );
-  char** keysY = (char**)malloc( sizeof( char* ) * nY );
-  char** valsYstr = (char**)malloc( sizeof( char* ) * nY );
-
-  size_t NX = 0;
-  char* p = strtok( fX, "," );
-  do {
-    char* q = strtok( NULL, "\n" );
-    if ( !q )
-      break;
-    keysX[NX] = p;
-    valsXstr[NX] = q;
-    NX++;
-  } while ( ( p = strtok( NULL, "," ) ) );
-
-  size_t NY = 0;
-  p = strtok( fY, "," );
-  do {
-    char* q = strtok( NULL, "\n" );
-    if ( !q )
-      break;
-    keysY[NY] = p;
-    valsYstr[NY] = q;
-    NY++;
-  } while ( ( p = strtok( NULL, "," ) ) );
-
-  size_t* valsX = (size_t*)malloc( sizeof( size_t ) * NX );
-  size_t* valsY = (size_t*)malloc( sizeof( size_t ) * NY );
-
-  for ( size_t i = 0; i < NX; i++ ) {
-    char* s = valsXstr[i];
-    uint32_t x = 0;
-    for ( size_t j = 0; j < 8; j++ ) {
-      char c = s[2 + j];
-      x |= decode( c ) << ( 7 - j ) * 4;
-    }
-    valsX[i] = x;
-  }
-  for ( size_t i = 0; i < NY; i++ ) {
-    char* s = valsYstr[i];
-    uint32_t x = 0;
-    for ( size_t j = 0; j < 8; j++ ) {
-      char c = s[2 + j];
-      x |= decode( c ) << ( 7 - j ) * 4;
-    }
-    valsY[i] = x;
+  uint64_t f[256];
+  for ( int i = 0; i < 256; i++ ) {
+    f[i] = fX[i] + fY[i];
   }
 
-  size_t N = NX + NY;
-  char** keys = (char**)malloc( sizeof( char* ) * N );
-  size_t* vals = (size_t*)malloc( sizeof( size_t ) * N );
-  size_t i = 0;
-  size_t ix = 0;
-  size_t iy = 0;
-
-  while ( ix < NX || iy < NY ) {
-    if ( ix >= NX ) {
-      keys[i] = keysY[iy];
-      vals[i] = valsY[iy];
-      i++;
-      iy++;
-      continue;
-    } else if ( iy >= NY ) {
-      keys[i] = keysX[ix];
-      vals[i] = valsX[ix];
-      i++;
-      ix++;
-      continue;
-    }
-
-    int cmp = strcmp( keysX[ix], keysY[iy] );
-
-    if ( cmp < 0 ) {
-      keys[i] = keysX[ix];
-      vals[i] = valsX[ix];
-      i++;
-      ix++;
-    } else if ( cmp == 0 ) {
-      keys[i] = keysX[ix];
-      vals[i] = valsX[ix] + valsY[iy];
-      i++;
-      ix++;
-      iy++;
-    } else {
-      keys[i] = keysY[iy];
-      vals[i] = valsY[iy];
-      i++;
-      iy++;
-    }
+  if ( grow_rw_mem_0_pages( 1 ) == -1 ) {
+    out( "merge counts: grow error" );
   }
+  program_mem_to_rw_mem_0( 0, f, sizeof( f ) );
 
-  size_t n = i;
-  size_t char_count = 0;
-  for ( size_t i = 0; i < n; i++ ) {
-    char* current = keys[i];
-    char_count += strlen( current );
-  }
-
-  size_t output_bytes = char_count + n * ( 1 + 10 + 1 );
-  char* output = (char*)malloc( output_bytes );
-
-  char* cursor = output;
-  for ( size_t i = 0; i < n; i++ ) {
-    size_t m = strlen( keys[i] );
-    strcpy( cursor, keys[i] );
-    cursor += m;
-    *cursor++ = ',';
-    *cursor++ = '0';
-    *cursor++ = 'x';
-    for ( size_t j = 0; j < 32; j += 4 ) {
-      size_t shift = ( 28 - j );
-      int x = vals[i] >> shift;
-      char y = "0123456789abcdef"[x];
-      *cursor++ = y;
-    }
-    *cursor++ = '\n';
-  }
-
-  size_t pages = output_bytes / 4096 + 1;
-  grow_rw_mem_0_pages( pages );
-  program_mem_to_rw_mem_0( 0, output, output_bytes );
-
-  return create_blob_rw_mem_0( output_bytes );
+  return create_blob_rw_mem_0( sizeof( f ) );
 }

--- a/applications/mapreduce/mapreduce.cc
+++ b/applications/mapreduce/mapreduce.cc
@@ -3,21 +3,29 @@ extern "C" {
 }
 #include <cassert>
 
-externref mapreduce( externref mapper, externref reducer, externref rlimits, int start, int end )
+extern externref create_identification_thunk( externref pointer )
+  __attribute__( ( import_module( "fixpoint" ), import_name( "create_identification_thunk" ) ) );
+
+externref mapreduce( externref mapper,
+                     externref reducer,
+                     externref rlimitsm,
+                     externref rlimitsr,
+                     int start,
+                     int end )
 {
   auto nil = create_blob_rw_mem_0( 0 );
   if ( start == end or start == end - 1 ) {
     grow_rw_table_0( 3, nil );
-    set_rw_table_0( 0, rlimits );
+    set_rw_table_0( 0, rlimitsm );
     set_rw_table_0( 1, mapper );
-    set_rw_table_0( 2, get_ro_table_0( start ) );
+    set_rw_table_0( 2, create_strict_encode( create_identification_thunk( get_ro_table_0( start ) ) ) );
     return create_application_thunk( create_tree_rw_table_0( 3 ) );
   } else {
     auto split = start + ( end - start ) / 2;
-    externref first = create_strict_encode( mapreduce( mapper, reducer, rlimits, start, split ) );
-    externref second = create_strict_encode( mapreduce( mapper, reducer, rlimits, split, end ) );
+    externref first = create_strict_encode( mapreduce( mapper, reducer, rlimitsm, rlimitsr, start, split ) );
+    externref second = create_strict_encode( mapreduce( mapper, reducer, rlimitsm, rlimitsr, split, end ) );
     grow_rw_table_0( 4, nil );
-    set_rw_table_0( 0, rlimits );
+    set_rw_table_0( 0, rlimitsr );
     set_rw_table_0( 1, reducer );
     set_rw_table_0( 2, first );
     set_rw_table_0( 3, second );
@@ -25,11 +33,21 @@ externref mapreduce( externref mapper, externref reducer, externref rlimits, int
   }
 }
 
+struct rlimits
+{
+  uint64_t memory;
+  uint64_t output_size;
+  uint64_t output_fanout;
+};
+static_assert( sizeof( rlimits ) == 24 );
+
 /**
  * @brief Applies a mapper and a reducer to a Tree, producing a single combined output.
  * @details The mapper is the second argument.
  *          The reducer is the third argument.
  *          The target is the fourth argument.
+ *          The rlimits to use for the mapper are the fifth argument.
+ *          The rlimits to use for the reducer are the sixth argument.
  * @return externref  A Thunk that evaluates to the result of the MapReduce operation.
  */
 __attribute__( ( export_name( "_fixpoint_apply" ) ) ) externref _fixpoint_apply( externref encode )
@@ -38,13 +56,15 @@ __attribute__( ( export_name( "_fixpoint_apply" ) ) ) externref _fixpoint_apply(
 
   attach_tree_ro_table_0( encode );
 
-  auto rlimits = get_ro_table_0( 0 );
+  /* auto rlimits = get_ro_table_0( 0 ); */
   /* auto self = get_ro_table_0(1); */
   auto mapper = get_ro_table_0( 2 );
   auto reducer = get_ro_table_0( 3 );
   auto target = get_ro_table_0( 4 );
+  auto rlimitsm = get_ro_table_0( 5 );
+  auto rlimitsr = get_ro_table_0( 6 );
 
   attach_tree_ro_table_0( target );
   auto N = get_length( target );
-  return mapreduce( mapper, reducer, rlimits, 0, N );
+  return mapreduce( mapper, reducer, rlimitsm, rlimitsr, 0, N );
 }

--- a/src/handle/handle_post.hh
+++ b/src/handle/handle_post.hh
@@ -1,5 +1,4 @@
 #pragma once
-#include <concepts>
 #include <variant>
 
 #include "handle.hh"
@@ -30,13 +29,13 @@ inline std::optional<Handle<S>> extract( Handle<T> original )
 }
 
 template<typename T>
-static inline Handle<AnyDataType> data( Handle<T> handle )
+static inline std::optional<Handle<AnyDataType>> data( Handle<T> handle )
 {
   if constexpr ( std::same_as<T, Relation> ) {
     return handle;
   } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef>
                         or std::same_as<T, BlobRef> ) {
-    __builtin_unreachable();
+    return {};
   } else if constexpr ( not Handle<T>::is_fix_sum_type ) {
     return handle;
   } else {
@@ -131,7 +130,7 @@ Handle<T> tree_unwrap( Handle<AnyTree> handle )
 template<FixTreeType T>
 Handle<T> tree_unwrap( Handle<Expression> handle )
 {
-  return data( handle ).visit<Handle<T>>( [&]( auto t ) -> Handle<T> {
+  return data( handle )->visit<Handle<T>>( [&]( auto t ) -> Handle<T> {
     if constexpr ( std::constructible_from<Handle<T>, decltype( t )> ) {
       return Handle<T>( t );
     } else {

--- a/src/handle/handle_post.hh
+++ b/src/handle/handle_post.hh
@@ -79,11 +79,12 @@ template<typename T>
 static inline size_t byte_size( Handle<T> handle )
 {
   if constexpr ( std::same_as<T, Relation> ) {
-    return sizeof( Handle<Fix> );
-  } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> ) {
+    return 0;
+  } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef>
+                        or std::same_as<T, BlobRef> ) {
     return 0;
   } else if constexpr ( std::same_as<T, Thunk> ) {
-    return sizeof( Handle<Fix> );
+    return 0;
   } else if constexpr ( not Handle<T>::is_fix_sum_type ) {
     return handle.size();
   } else {

--- a/src/handle/handle_post.hh
+++ b/src/handle/handle_post.hh
@@ -54,13 +54,13 @@ static inline bool is_local( Handle<T> handle )
         return x.is_local();
       }
     },
-    data( handle ).get() );
+    data( handle ).value().get() );
 }
 
 template<typename T>
 static inline size_t local_name( Handle<T> handle )
 {
-  return std::visit( []( const auto x ) { return x.local_name(); }, data( handle ).get() );
+  return std::visit( []( const auto x ) { return x.local_name(); }, data( handle ).value().get() );
 }
 
 template<typename T>

--- a/src/handle/operators.hh
+++ b/src/handle/operators.hh
@@ -85,7 +85,10 @@ inline std::ostream& operator<<( std::ostream& os, const Handle<Tree<T>>& h )
   } else if constexpr ( std::same_as<T, Expression> ) {
     os << "Expression";
   }
-  os << "Tree " << h.size() << " ";
+  if ( h.is_tag() )
+    os << "Tag " << h.size() << " ";
+  else
+    os << "Tree " << h.size() << " ";
   if ( h.is_local() ) {
     os << "(Local " << h.local_name() << ")";
   } else {

--- a/src/runtime/fixpointapi.cc
+++ b/src/runtime/fixpointapi.cc
@@ -104,9 +104,9 @@ void unsafe_io( int32_t index, int32_t length, wasm_rt_memory_t* mem )
     wasm_rt_trap( WASM_RT_TRAP_OOB );
   }
   for ( int i = index; i < index + length; i++ ) {
-    cout << mem->data[i];
+    cerr << mem->data[i];
   }
-  cout << endl;
+  cerr << endl;
   flush( cout );
 }
 

--- a/src/runtime/message.cc
+++ b/src/runtime/message.cc
@@ -257,13 +257,31 @@ InfoPayload InfoPayload::parse( Parser& parser )
     throw runtime_error( "Failed to parse link speed." );
   }
 
-  return { { .parallelism = parallelism, .link_speed = link_speed } };
+  size_t data_entries {};
+  parser.integer<size_t>( data_entries );
+  if ( parser.error() ) {
+    throw runtime_error( "Failed to parse number of entries in data." );
+  }
+
+  InfoPayload payload;
+  payload.parallelism = parallelism;
+  payload.link_speed = link_speed;
+  payload.data.reserve( data_entries );
+
+  for ( size_t i = 0; i < data_entries; i++ ) {
+    payload.data.insert( parse_handle<AnyDataType>( parser ) );
+  }
+  return payload;
 }
 
 void InfoPayload::serialize( Serializer& serializer ) const
 {
   serializer.integer( parallelism );
   serializer.integer( link_speed );
+  serializer.integer( data.size() );
+  for ( const auto& h : data ) {
+    serializer.integer( h.content );
+  }
 }
 
 template<Message::Opcode O>

--- a/src/runtime/message.hh
+++ b/src/runtime/message.hh
@@ -101,13 +101,20 @@ struct RequestTreePayload
   size_t payload_length() const { return sizeof( u8x32 ); }
 };
 
-struct InfoPayload : public IRuntime::Info
+struct InfoPayload
 {
+  uint32_t parallelism {};
+  double link_speed {};
+  std::unordered_set<Handle<AnyDataType>> data {};
+
   static InfoPayload parse( Parser& parser );
   void serialize( Serializer& serializer ) const;
 
   constexpr static Message::Opcode OPCODE = Message::Opcode::INFO;
-  size_t payload_length() const { return sizeof( uint32_t ) + sizeof( double ); }
+  size_t payload_length() const
+  {
+    return sizeof( uint32_t ) + sizeof( double ) + sizeof( size_t ) + data.size() * sizeof( u8x32 );
+  }
 };
 
 template<Message::Opcode O>

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -236,7 +236,10 @@ std::optional<Handle<AnyTree>> Remote::contains( Handle<AnyTreeRef> handle )
   auto entry = trees_view_.read()->find( handle::upcast( tmp_tree ) );
 
   if ( entry == trees_view_.read()->end() ) {
-    return {};
+    entry = loadable_trees_view_.read()->find( handle::upcast( tmp_tree ) );
+    if ( entry == loadable_trees_view_.read()->end() ) {
+      return {};
+    }
   }
 
   // Cast to same kind as Handle<AnyTreeRef>

--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -126,7 +126,7 @@ private:
   void process_incoming_message( IncomingMessage&& msg );
 
   void send_blob( BlobData blob );
-  void send_tree( TreeData tree );
+  void send_tree( Handle<AnyTree>, TreeData tree );
 
   void clean_up();
 

--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -79,7 +79,7 @@ class Remote : public IRuntime
   SharedMutex<absl::flat_hash_set<Handle<Relation>, AbslHash>> relations_view_ {};
 
   SharedMutex<absl::flat_hash_set<Handle<Named>, AbslHash>> loadable_blobs_view_ {};
-  SharedMutex<absl::flat_hash_set<Handle<ExpressionTree>, AbslHash>> loadable_trees_view_ {};
+  SharedMutex<absl::flat_hash_set<Handle<ExpressionTree>, AbslHash, handle::tree_equal>> loadable_trees_view_ {};
   SharedMutex<absl::flat_hash_set<Handle<Relation>, AbslHash>> loadable_relations_view_ {};
 
 public:

--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -76,6 +76,10 @@ class Remote : public IRuntime
   SharedMutex<absl::flat_hash_set<Handle<ExpressionTree>, AbslHash>> trees_view_ {};
   SharedMutex<absl::flat_hash_set<Handle<Relation>, AbslHash>> relations_view_ {};
 
+  SharedMutex<absl::flat_hash_set<Handle<Named>, AbslHash>> loadable_blobs_view_ {};
+  SharedMutex<absl::flat_hash_set<Handle<ExpressionTree>, AbslHash>> loadable_trees_view_ {};
+  SharedMutex<absl::flat_hash_set<Handle<Relation>, AbslHash>> loadable_relations_view_ {};
+
 public:
   Remote( EventLoop& events,
           EventCategories categories,
@@ -125,6 +129,10 @@ private:
   void send_tree( TreeData tree );
 
   void clean_up();
+
+  bool loaded( Handle<Named> handle );
+  bool loaded( Handle<AnyTree> handle );
+  bool loaded( Handle<Relation> handle );
 };
 
 class NetworkWorker

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -166,4 +166,5 @@ public:
   }
 
   Repository& get_repository() { return repository_; }
+  virtual std::unordered_set<Handle<AnyDataType>> data() const override { return repository_.data(); }
 };

--- a/src/runtime/runner.hh
+++ b/src/runtime/runner.hh
@@ -39,11 +39,6 @@ public:
 
   virtual Handle<Object> apply( Handle<ObjectTree> handle, TreeData combination ) override
   {
-    // Check minrepo are all loaded
-    if ( not fixpoint::storage->complete( handle ) ) {
-      throw std::runtime_error( "Incomplete minrepo." );
-    }
-
     std::optional<Handle<AnyTree>> function_tag {};
 
     auto rlimits = combination->at( 0 );

--- a/src/runtime/runtimes.cc
+++ b/src/runtime/runtimes.cc
@@ -55,9 +55,11 @@ Server::~Server()
   network_worker_->stop();
 }
 
-shared_ptr<Server> Server::init( const Address& address, vector<Address> peer_servers )
+shared_ptr<Server> Server::init( const Address& address,
+                                 shared_ptr<Scheduler> scheduler,
+                                 vector<Address> peer_servers )
 {
-  auto runtime = std::make_shared<Server>();
+  auto runtime = std::make_shared<Server>( scheduler );
   runtime->network_worker_.emplace( runtime->relater_ );
   runtime->network_worker_->start();
 

--- a/src/runtime/runtimes.hh
+++ b/src/runtime/runtimes.hh
@@ -54,12 +54,16 @@ public:
 class Server
 {
 protected:
-  Relater relater_ {};
+  Relater relater_;
   std::optional<NetworkWorker> network_worker_ {};
 
 public:
-  Server() {}
+  Server( std::shared_ptr<Scheduler> scheduler )
+    : relater_( std::thread::hardware_concurrency(), {}, scheduler )
+  {}
 
-  static std::shared_ptr<Server> init( const Address& address, const std::vector<Address> peer_servers = {} );
+  static std::shared_ptr<Server> init( const Address& address,
+                                       std::shared_ptr<Scheduler> scheduler,
+                                       const std::vector<Address> peer_servers = {} );
   ~Server();
 };

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -177,6 +177,9 @@ public:
       visited.insert( handle );
     }
   }
+
+  // Return the list of data presening in .fix repository
+  virtual std::unordered_set<Handle<AnyDataType>> data() const { return {}; };
 };
 
 class MultiWorkerRuntime : public IRuntime

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -156,6 +156,7 @@ public:
           = handle.template visit<Handle<Thunk>>( []( auto s ) { return s.template unwrap<Thunk>(); } );
         thunk.visit<void>(
           overload { [&]( Handle<Application> a ) { visit( a.unwrap<ExpressionTree>(), visitor, visited ); },
+                     [&]( Handle<Identification> i ) { visit( i.unwrap<Value>(), visitor, visited ); },
                      []( auto ) {} } );
       }
 
@@ -166,10 +167,12 @@ public:
       return;
     } else {
       if constexpr ( FixTreeType<T> ) {
-        // Having the handle means that the data presents in storage
-        auto tree = get( handle );
-        for ( const auto& element : tree.value()->span() ) {
-          visit( element, visitor, visited );
+        if ( contains( handle ) ) {
+          // Having the handle means that the data presents in storage
+          auto tree = get( handle );
+          for ( const auto& element : tree.value()->span() ) {
+            visit( element, visitor, visited );
+          }
         }
       }
       VLOG( 3 ) << "visiting " << handle;

--- a/src/storage/repository.cc
+++ b/src/storage/repository.cc
@@ -44,7 +44,8 @@ std::unordered_set<Handle<AnyDataType>> Repository::data() const
   try {
     std::unordered_set<Handle<AnyDataType>> result;
     for ( const auto& datum : fs::directory_iterator( repo_ / "data" ) ) {
-      result.insert( handle::data( Handle<Fix>::forge( base16::decode( datum.path().filename().string() ) ) ) );
+      result.insert(
+        handle::data( Handle<Fix>::forge( base16::decode( datum.path().filename().string() ) ) ).value() );
     }
     return result;
   } catch ( std::filesystem::filesystem_error& ) {
@@ -376,12 +377,17 @@ Handle<Fix> Repository::lookup( const std::string_view ref )
 {
   if ( ref.size() == 64 ) {
     auto handle = Handle<Fix>::forge( base16::decode( ref ) );
-    if ( handle::data( handle ).visit<bool>( overload {
-           [&]( Handle<Literal> ) { return true; },
-           [&]( auto x ) { return contains( x ); },
-         } ) )
+    if ( handle::data( handle ).has_value() ) {
+      if ( handle::data( handle )->visit<bool>( overload {
+             [&]( Handle<Literal> ) { return true; },
+             [&]( auto x ) { return contains( x ); },
+           } ) )
+        return handle;
+    } else {
       return handle;
+    }
   }
+
   try {
     return labeled( ref );
   } catch ( LabelNotFound& ) {}
@@ -392,7 +398,7 @@ Handle<Fix> Repository::lookup( const std::string_view ref )
     if ( name.rfind( ref, 0 ) == 0 ) {
       if ( candidate )
         throw AmbiguousReference( ref );
-      candidate = handle::data( handle::fix( handle ) );
+      candidate = handle::data( handle::fix( handle ) ).value();
     }
   }
   if ( candidate )

--- a/src/storage/repository.cc
+++ b/src/storage/repository.cc
@@ -386,17 +386,17 @@ Handle<Fix> Repository::lookup( const std::string_view ref )
     return labeled( ref );
   } catch ( LabelNotFound& ) {}
 
-  std::optional<Handle<Fix>> candidate;
+  std::optional<Handle<AnyDataType>> candidate;
   for ( const auto& handle : data() ) {
     std::string name = base16::encode( handle.content );
     if ( name.rfind( ref, 0 ) == 0 ) {
       if ( candidate )
         throw AmbiguousReference( ref );
-      candidate = handle::fix( handle );
+      candidate = handle::data( handle::fix( handle ) );
     }
   }
   if ( candidate )
-    return *candidate;
+    return handle::fix( *candidate );
 
   if ( fs::exists( ref ) ) {
     try {

--- a/src/storage/runtimestorage.cc
+++ b/src/storage/runtimestorage.cc
@@ -428,16 +428,6 @@ bool RuntimeStorage::compare_handles( Handle<Fix> x, Handle<Fix> y )
 }
 #endif
 
-bool RuntimeStorage::complete( Handle<Fix> handle )
-{
-  bool res {};
-  visit( handle, [&]( Handle<Fix> h ) {
-    res |= handle::data( h ).visit<bool>(
-      overload { []( Handle<Literal> ) { return true; }, [&]( auto h ) { return contains( h ); } } );
-  } );
-  return res;
-}
-
 #if 0
 std::vector<Handle<Fix>> RuntimeStorage::minrepo( Handle<Fix> handle )
 {

--- a/src/storage/runtimestorage.hh
+++ b/src/storage/runtimestorage.hh
@@ -171,11 +171,6 @@ public:
   bool compare_handles( Handle<Fix> x, Handle<Fix> y );
 
   /**
-   * Checks if @p root, as well as all its dependencies, are resident in storage.
-   */
-  bool complete( Handle<Fix> root );
-
-  /**
    * Computes the minimum repository of @p root.
    */
   std::vector<Handle<Fix>> minrepo( Handle<Fix> root );

--- a/src/tester/CMakeLists.txt
+++ b/src/tester/CMakeLists.txt
@@ -10,5 +10,8 @@ target_link_libraries(fixpoint-server runtime)
 add_executable(fixpoint-client "fixpoint-client.cc" "main.cc" "tester-utils.cc")
 target_link_libraries(fixpoint-client runtime)
 
+add_executable(fixpoint-client-wikipedia "fixpoint-client-wikipedia.cc" "tester-utils.cc")
+target_link_libraries(fixpoint-client-wikipedia runtime)
+
 # add_executable(http-tester "http-tester.cc" "main.cc" "tester-utils.cc")
 # target_link_libraries(http-tester runtime http)

--- a/src/tester/fixpoint-client-wikipedia.cc
+++ b/src/tester/fixpoint-client-wikipedia.cc
@@ -1,0 +1,65 @@
+#include <iostream>
+#include <unistd.h>
+
+#include "handle_post.hh"
+#include "runtimes.hh"
+#include "tester-utils.hh"
+
+using namespace std;
+
+int min_args = 0;
+int max_args = -1;
+
+int main( int argc, char* argv[] )
+{
+  std::shared_ptr<Client> client;
+
+  if ( argc != 2 ) {
+    cerr << "Usage: +[address]:[port]" << endl;
+    exit( 1 );
+  }
+
+  if ( argv[1][0] == '+' ) {
+    string addr( &argv[1][1] );
+    if ( addr.find( ':' ) == string::npos ) {
+      throw runtime_error( "invalid argument " + addr );
+    }
+    Address address( addr.substr( 0, addr.find( ':' ) ), stoi( addr.substr( addr.find( ':' ) + 1 ) ) );
+    client = Client::init( address );
+  } else {
+    exit( 1 );
+  }
+  auto& rt = client->get_rt();
+
+  auto mapreduce = rt.labeled( "mapreduce" ).unwrap<Expression>().unwrap<Object>().unwrap<Value>();
+  auto mapper = rt.labeled( "count-words" ).unwrap<Expression>().unwrap<Object>().unwrap<Value>();
+  auto reducer = rt.labeled( "merge-counts" ).unwrap<Expression>().unwrap<Object>().unwrap<Value>();
+  auto wikipedia = rt.labeled( "wikipedia" ).unwrap<Expression>().unwrap<Object>().unwrap<Value>();
+
+  auto application = OwnedMutTree::allocate( 7 );
+  application[0] = make_limits( rt, 1024 * 1024 * 1024, 1024 * 1024, 1, false );
+  application[1] = mapreduce;
+  application[2] = mapper;
+  application[3] = reducer;
+  application[4] = wikipedia;
+  application[5] = make_limits( rt, 1024 * 1024 * 1024, 256 * 8, 1, false );
+  application[6] = make_limits( rt, 1024 * 1024 * 1024, 256 * 8, 1, true );
+
+  auto handle = rt.create( make_shared<OwnedTree>( std::move( application ) ) ).unwrap<ValueTree>();
+  auto res = client->execute( Handle<Eval>( Handle<Object>( Handle<Application>( handle::upcast( handle ) ) ) ) );
+  /* auto res = client->execute( Handle<Eval>( Handle<Identification>( wikipedia ) ) ); */
+
+  // print the result
+  cerr << "Result:\n" << res << endl;
+  cerr << "Result:\n" << res.content << endl;
+
+  auto named = res.unwrap<Blob>().unwrap<Named>();
+  auto result = client->get_rt().get( named ).value();
+
+  if ( std::filesystem::exists( "wikipedia.out" ) ) {
+    std::filesystem::remove( "wikipedia.out" );
+  }
+  result->to_file( "wikipedia.out" );
+
+  return 0;
+}

--- a/src/tester/fixpoint-server.cc
+++ b/src/tester/fixpoint-server.cc
@@ -1,4 +1,8 @@
 #include <iostream>
+#include <stdexcept>
+extern "C" {
+#include <sys/resource.h>
+}
 
 #include "mmap.hh"
 #include "option-parser.hh"
@@ -23,6 +27,19 @@ void split( const string_view str, const char ch_to_find, vector<string_view>& r
 
 int main( int argc, char* argv[] )
 {
+  const rlim_t stack_size = 4u * 1024 * 1024 * 1024;
+  struct rlimit rlimit;
+  if ( getrlimit( RLIMIT_STACK, &rlimit ) ) {
+    cerr << "Could not get stack size." << endl;
+    exit( 1 );
+  }
+  rlimit.rlim_cur = std::min( stack_size, rlimit.rlim_max );
+  if ( setrlimit( RLIMIT_STACK, &rlimit ) ) {
+    cerr << "Could not increase stack size to " << stack_size << " bytes." << endl;
+    exit( 1 );
+  }
+  VLOG( 1 ) << "Stack size set to " << rlimit.rlim_cur << " bytes" << endl;
+
   OptionParser parser( "fixpoint-server", "Run a fixpoint server" );
   uint16_t port;
   optional<const char*> local;

--- a/src/tester/tester-utils.hh
+++ b/src/tester/tester-utils.hh
@@ -6,11 +6,11 @@
 Handle<Fix> parse_args( IRuntime& rt, std::span<char*>& args );
 void parser_usage_message();
 
-static Handle<ValueTree> make_limits( IRuntime& rt,
-                                      uint64_t memory,
-                                      uint64_t output_size,
-                                      uint64_t output_fanout,
-                                      bool fast = false )
+[[maybe_unused]] static Handle<ValueTree> make_limits( IRuntime& rt,
+                                                       uint64_t memory,
+                                                       uint64_t output_size,
+                                                       uint64_t output_fanout,
+                                                       bool fast = false )
 {
   auto tree = OwnedMutTree::allocate( 4 );
   tree.at( 0 ) = Handle<Literal>( memory );
@@ -21,7 +21,7 @@ static Handle<ValueTree> make_limits( IRuntime& rt,
   return handle::extract<ValueTree>( created ).value();
 }
 
-static Handle<Fix> make_identification( Handle<Fix> name )
+[[maybe_unused]] static Handle<Fix> make_identification( Handle<Fix> name )
 {
   return handle::extract<Value>( name )
     .transform( [&]( auto h ) -> Handle<Fix> {

--- a/src/tester/tester-utils.hh
+++ b/src/tester/tester-utils.hh
@@ -5,3 +5,44 @@
 
 Handle<Fix> parse_args( IRuntime& rt, std::span<char*>& args );
 void parser_usage_message();
+
+static Handle<ValueTree> make_limits( IRuntime& rt,
+                                      uint64_t memory,
+                                      uint64_t output_size,
+                                      uint64_t output_fanout,
+                                      bool fast = false )
+{
+  auto tree = OwnedMutTree::allocate( 4 );
+  tree.at( 0 ) = Handle<Literal>( memory );
+  tree.at( 1 ) = Handle<Literal>( output_size );
+  tree.at( 2 ) = Handle<Literal>( output_fanout );
+  tree.at( 3 ) = Handle<Literal>( (uint8_t)fast );
+  auto created = rt.create( std::make_shared<OwnedTree>( std::move( tree ) ) );
+  return handle::extract<ValueTree>( created ).value();
+}
+
+static Handle<Fix> make_identification( Handle<Fix> name )
+{
+  return handle::extract<Value>( name )
+    .transform( [&]( auto h ) -> Handle<Fix> {
+      return h.template visit<Handle<Fix>>(
+        overload { []( Handle<Blob> b ) { return Handle<Identification>( b ); },
+                   []( Handle<ValueTree> t ) { return Handle<Identification>( t ); },
+                   [&]( auto ) { return name; } } );
+    } )
+    .or_else( [&]() -> std::optional<Handle<Fix>> { throw std::runtime_error( "Not Identification-able" ); } )
+    .value();
+}
+
+[[maybe_unused]] static Handle<Application> make_compile( IRuntime& rt, Handle<Fix> wasm )
+{
+  auto compiler = rt.labeled( "compile-encode" );
+
+  auto tree = OwnedMutTree::allocate( 3 );
+  tree.at( 0 ) = make_limits( rt, 1024 * 1024 * 1024, 1024 * 1024, 1 );
+  tree.at( 1 ) = Handle<Strict>( handle::extract<Identification>( make_identification( compiler ) ).value() );
+  tree.at( 2 ) = wasm;
+  return rt.create( std::make_shared<OwnedTree>( std::move( tree ) ) ).visit<Handle<Application>>( []( auto x ) {
+    return Handle<Application>( Handle<ExpressionTree>( x ) );
+  } );
+}

--- a/src/tests/test-mapreduce.cc
+++ b/src/tests/test-mapreduce.cc
@@ -40,7 +40,8 @@ void test( void )
                                 14_literal32,
                                 15_literal32 );
 
-  auto thunk = Handle<Thunk>( tester::Tree( tester::Limits(), mapreduce, add100, sum, original ) );
+  auto thunk = Handle<Thunk>(
+    tester::Tree( tester::Limits(), mapreduce, add100, sum, original, tester::Limits(), tester::Limits() ) );
   auto result = tester::rt->execute( Handle<Eval>( thunk ) );
 
   cout << result << endl;

--- a/wikipedia/.gitignore
+++ b/wikipedia/.gitignore
@@ -1,0 +1,1 @@
+repo-template

--- a/wikipedia/load.sh
+++ b/wikipedia/load.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+rm -rf .fix
+fix init
+refs=""
+for chunk in /usr/local/share/wikipedia/chunks-1G/*
+do
+  echo $chunk
+  refs+=$(fix ref $(fix add $chunk))
+  refs+=" "
+done
+fix create-tree -l "wikipedia" $refs

--- a/wikipedia/mktemplate.sh
+++ b/wikipedia/mktemplate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+TEMP=$(mktemp -d)
+pushd $TEMP
+tar -xzf /usr/local/share/bootstrap/bootstrap.tar.gz
+pushd ~/fix
+cmake --build build --parallel
+popd
+fix add ~/fix/build/applications-prefix/src/applications-build/mapreduce/mapreduce.wasm -l mapreduce-wasm > /dev/null
+fix add ~/fix/build/applications-prefix/src/applications-build/count-words/count_words.wasm -l count-words-wasm > /dev/null
+fix add ~/fix/build/applications-prefix/src/applications-build/count-words/merge_counts.wasm -l merge-counts-wasm > /dev/null
+fix label $(fix eval compile: label:mapreduce-wasm) mapreduce
+fix label $(fix eval compile: label:count-words-wasm) count-words
+fix label $(fix eval compile: label:merge-counts-wasm) merge-counts
+popd
+rm -rf repo-template
+mv $TEMP/.fix repo-template
+rm -rf $TEMP

--- a/wikipedia/scatter.sh
+++ b/wikipedia/scatter.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Usage: ./scatter.sh ip-or-hostname1:path/to/folder ip-or-hostname2:path/to/folder...
+
+if [ "$#" -eq 0 ]
+then
+  echo "Must specify targets to scatter files." >&2
+  exit 1
+fi
+
+trap "exit" INT
+
+NODES=($@)
+IFS=$'\n'
+CHUNKS=($(fix ls-tree wikipedia | cut -d' ' -f4 | sed "s/500\$/400/"))
+M=${#NODES[@]}
+N=${#CHUNKS[@]}
+QUOTIENT=$((N / M))
+REMAINDER=$((N % M))
+
+for i in $(seq 0 $(($M-1)))
+do
+  target=${NODES[$i]}
+  echo "Sending template fix directory to $target."
+  rsync -a --delete repo-template/ $target/.fix/
+done
+
+for i in $(seq 0 $(($M-1)))
+do
+  target=${NODES[$i]}
+  echo "Sending $QUOTIENT file(s) to $target."
+  for j in $(seq 0 $(($QUOTIENT - 1)))
+  do
+    k=$(($i * $QUOTIENT + $j))
+    rsync -a --ignore-existing .fix/data/${CHUNKS[$k]} $target/.fix/data/ &
+  done
+  wait
+done
+for j in $(seq 0 $(($REMAINDER - 1)))
+do
+  k=$(($M * $QUOTIENT + $j))
+  target=${NODES[$j]}
+  echo "Sending extra file to $target."
+  rsync -a --ignore-existing .fix/data/${CHUNKS[$k]} $target/.fix/data/ &
+done
+wait
+
+
+target=${NODES[0]}
+echo "Sending label to $target."
+rsync -a $(readlink -f .fix/labels/wikipedia) $target/.fix/data/
+rsync -a .fix/labels/wikipedia $target/.fix/labels/


### PR DESCRIPTION
* Repository::data() is sent as part of INFO message and considered `loadable` by the other side. Any `loadable` data is not absent when the scheduler calculates `absent_size`, but would still be proposed as part of `ProposeData`. This avoids the workaround in `fixpoint-mapreduce-server.cc` on `wikipedia` branch.
*  Add Wikipedia-related changes from `wikipedia` branch.
* Fix synchronization issues related to `ProposeTransfer`/`AcceptTransfer`.