### PR TITLE
Pass

### DIFF
--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -21,6 +21,7 @@ add_test(NAME u_distributed COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-d
 add_test(NAME u_blake3 WORKING_DIRECTORY COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-blake3)
 add_test(NAME u_dependency_graph COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-dependency-graph)
 add_test(NAME u_scheduler COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-scheduler)
+add_test(NAME u_relater COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-relater)
 
 add_test(NAME t_add COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-add)
 add_test(NAME t_fib COMMAND ${CMAKE_CURRENT_BINARY_DIR}/src/tests/test-fib)

--- a/src/handle/handle_post.hh
+++ b/src/handle/handle_post.hh
@@ -33,8 +33,8 @@ static inline std::optional<Handle<AnyDataType>> data( Handle<T> handle )
 {
   if constexpr ( std::same_as<T, Relation> ) {
     return handle;
-  } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef>
-                        or std::same_as<T, BlobRef> ) {
+  } else if constexpr ( std::same_as<T, ValueTreeRef> or std::same_as<T, ObjectTreeRef> or std::same_as<T, BlobRef>
+                        or std::same_as<T, Thunk> ) {
     return {};
   } else if constexpr ( not Handle<T>::is_fix_sum_type ) {
     return handle;

--- a/src/runtime/dependency_graph.hh
+++ b/src/runtime/dependency_graph.hh
@@ -91,12 +91,5 @@ public:
     }
   }
 
-  void erase_backward_dependencies( Task blocked )
-  {
-    for ( auto dependency : forward_dependencies_[blocked] ) {
-      backward_dependencies_[dependency].erase( blocked );
-      dependency.visit<void>(
-        overload { [&]( Handle<Relation> r ) { erase_backward_dependencies( r ); }, []( auto ) {} } );
-    }
-  }
+  void erase_forward_dependencies( Task blocked ) { forward_dependencies_.erase( blocked ); }
 };

--- a/src/runtime/dependency_graph.hh
+++ b/src/runtime/dependency_graph.hh
@@ -91,15 +91,12 @@ public:
     }
   }
 
-  void erase_backward_dependencies( Task blocked ) {
+  void erase_backward_dependencies( Task blocked )
+  {
     for ( auto dependency : forward_dependencies_[blocked] ) {
       backward_dependencies_[dependency].erase( blocked );
-      dependency.visit<void>( overload {
-          [&]( Handle<Relation> r ) {
-            erase_backward_dependencies( r );
-          },
-          []( auto ) {}
-      } );
+      dependency.visit<void>(
+        overload { [&]( Handle<Relation> r ) { erase_backward_dependencies( r ); }, []( auto ) {} } );
     }
   }
 };

--- a/src/runtime/dependency_graph.hh
+++ b/src/runtime/dependency_graph.hh
@@ -84,6 +84,16 @@ public:
 
   absl::flat_hash_set<Handle<AnyDataType>> get_forward_dependencies( Task blocked ) const
   {
-    return forward_dependencies_.at( blocked );
+    if ( forward_dependencies_.contains( blocked ) ) {
+      return forward_dependencies_.at( blocked );
+    } else {
+      return {};
+    }
+  }
+
+  void erase_backward_dependencies( Task blocked ) {
+    for ( const auto dependency : forward_dependencies_[blocked] ) {
+      backward_dependencies_[dependency].erase( blocked );
+    }
   }
 };

--- a/src/runtime/dependency_graph.hh
+++ b/src/runtime/dependency_graph.hh
@@ -92,8 +92,14 @@ public:
   }
 
   void erase_backward_dependencies( Task blocked ) {
-    for ( const auto dependency : forward_dependencies_[blocked] ) {
+    for ( auto dependency : forward_dependencies_[blocked] ) {
       backward_dependencies_[dependency].erase( blocked );
+      dependency.visit<void>( overload {
+          [&]( Handle<Relation> r ) {
+            erase_backward_dependencies( r );
+          },
+          []( auto ) {}
+      } );
     }
   }
 };

--- a/src/runtime/executor.cc
+++ b/src/runtime/executor.cc
@@ -38,8 +38,8 @@ Executor::~Executor()
 void Executor::run()
 {
   static std::mutex error_mutex;
+  Handle<AnyDataType> next;
   try {
-    Handle<AnyDataType> next;
     while ( true ) {
       todo_ >> next;
       progress( next );
@@ -48,28 +48,28 @@ void Executor::run()
     std::unique_lock lock( error_mutex );
     cerr << "--- STORAGE ERROR ---\n";
     cerr << "what: " << e.what() << endl;
-    if ( current_ ) {
-      auto graph = parent_.graph_.write();
-      cerr << "backtrace:\n";
-      int i = 0;
-      auto current = current_.value();
-      cerr << ++i << ". ";
-      while ( true ) {
-        current.visit<void>( [&]( auto x ) { cerr << x; } );
-        cerr << endl;
-        i++;
-        absl::flat_hash_set<Handle<Relation>> unblocked;
-        graph->finish( current, unblocked );
-        if ( unblocked.empty() ) {
-          break;
-        }
-        cerr << i << ". ";
-        if ( unblocked.size() >= 2 ) {
-          cerr << std::format( "[1/{}] ", unblocked.size() );
-        }
-        current = *unblocked.begin();
+
+    auto graph = parent_.graph_.write();
+    cerr << "backtrace:\n";
+    int i = 0;
+    auto current = next;
+    cerr << ++i << ". ";
+    while ( true ) {
+      current.visit<void>( [&]( auto x ) { cerr << x; } );
+      cerr << endl;
+      i++;
+      absl::flat_hash_set<Handle<Relation>> unblocked;
+      graph->finish( current, unblocked );
+      if ( unblocked.empty() ) {
+        break;
       }
+      cerr << i << ". ";
+      if ( unblocked.size() >= 2 ) {
+        cerr << std::format( "[1/{}] ", unblocked.size() );
+      }
+      current = *unblocked.begin();
     }
+
     cerr << "---------------------\n";
     std::terminate();
   } catch ( ChannelClosed& ) {

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -143,7 +143,6 @@ optional<Handle<Object>> Remote::get( Handle<Relation> name )
     } );
   }
 
-  parent_->get().erase_backward_dependencies( name );
   RunPayload payload { .task = name };
   msg_q_.enqueue( make_pair( index_, move( payload ) ) );
 

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -142,8 +142,11 @@ optional<Handle<Object>> Remote::get( Handle<Relation> name )
                                 } } );
     } );
   }
+
+  parent_->get().erase_backward_dependencies( name );
   RunPayload payload { .task = name };
   msg_q_.enqueue( make_pair( index_, move( payload ) ) );
+
 
   return {};
 }

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -147,7 +147,6 @@ optional<Handle<Object>> Remote::get( Handle<Relation> name )
   RunPayload payload { .task = name };
   msg_q_.enqueue( make_pair( index_, move( payload ) ) );
 
-
   return {};
 }
 

--- a/src/runtime/network.cc
+++ b/src/runtime/network.cc
@@ -349,6 +349,7 @@ void Remote::process_incoming_message( IncomingMessage&& msg )
       {
         unique_lock lock( mutex_ );
         info_ = { .parallelism = payload.parallelism, .link_speed = payload.link_speed };
+        info_cv_.notify_all();
       }
 
       for ( auto handle : payload.data ) {

--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -18,7 +18,6 @@
 #include "interface.hh"
 #include "message.hh"
 #include "mutex.hh"
-#include "relater.hh"
 #include "ring_buffer.hh"
 #include "runtimestorage.hh"
 #include "socket.hh"
@@ -97,6 +96,7 @@ public:
   void put( Handle<Named> name, BlobData data ) override;
   void put( Handle<AnyTree> name, TreeData data ) override;
   void put( Handle<Relation> name, Handle<Object> data ) override;
+  void put_force( Handle<Relation> name, Handle<Object> data ) override;
 
   bool contains( Handle<Named> handle ) override;
   bool contains( Handle<AnyTree> handle ) override;

--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -114,7 +114,7 @@ public:
 
   bool dead() const { return dead_; }
 
-  virtual bool reply_to_contains( Handle<Relation> handle )
+  virtual bool reply_to_contains( Handle<Relation> handle ) override
   {
     std::shared_lock lock( mutex_ );
     return reply_to_.contains( handle );

--- a/src/runtime/network.hh
+++ b/src/runtime/network.hh
@@ -114,12 +114,6 @@ public:
 
   bool dead() const { return dead_; }
 
-  virtual bool reply_to_contains( Handle<Relation> handle ) override
-  {
-    std::shared_lock lock( mutex_ );
-    return reply_to_.contains( handle );
-  }
-
   bool erase_reply_to( Handle<Relation> handle )
   {
     std::unique_lock lock( mutex_ );

--- a/src/runtime/pass.cc
+++ b/src/runtime/pass.cc
@@ -220,6 +220,13 @@ void BasePass::independent( Handle<AnyDataType> job )
     if ( local->get_info().has_value() and local->get_info()->parallelism > 0 ) {
       tasks_info_[job].absent_size.insert( { local, absent_size( local, job ) } );
       VLOG( 2 ) << "local absent_size " << job << " " << tasks_info_[job].absent_size.at( local );
+
+      job.visit<void>( overload { [&]( auto r ) {
+                                   if ( local->contains( r ) ) {
+                                     tasks_info_[job].contains.insert( local );
+                                   }
+                                 },
+                                  []( Handle<Literal> ) {} } );
     }
   }
 

--- a/src/runtime/pass.cc
+++ b/src/runtime/pass.cc
@@ -98,9 +98,15 @@ void BasePass::leaf( Handle<AnyDataType> job )
                                    auto output_fan_out = handle::extract<Literal>( limits->at( 2 ) )
                                                            .transform( [&]( auto x ) { return uint64_t( x ); } )
                                                            .value_or( 1 );
+                                   bool ep = ( limits->size() > 3 )
+                                               ? handle::extract<Literal>( limits->at( 3 ) )
+                                                   .transform( [&]( auto x ) { return uint8_t( x ); } )
+                                                   .value_or( 0 )
+                                               : false;
 
                                    tasks_info_[job].output_size = output_size;
                                    tasks_info_[job].output_fan_out = output_fan_out;
+                                   tasks_info_[job].ep = ep;
                                  },
                                  [&]( Handle<Eval> ) {},
                                } );
@@ -129,45 +135,66 @@ void BasePass::post( Handle<AnyDataType> job, const absl::flat_hash_set<Handle<A
     output_size += out;
   }
 
-  auto outs = obj.visit<pair<size_t, size_t>>( overload {
+  auto outs = obj.visit<tuple<size_t, size_t, bool>>( overload {
     [&]( Handle<Thunk> t ) {
-      return t.visit<pair<size_t, size_t>>( overload {
-        [&]( Handle<Application> a ) -> pair<size_t, size_t> {
+      return t.visit<tuple<size_t, size_t, bool>>( overload {
+        [&]( Handle<Application> a ) -> tuple<size_t, size_t, bool> {
           if ( relater_.get().contains( a.unwrap<ExpressionTree>() ) ) {
             auto rlimits = relater_.get().get( a.unwrap<ExpressionTree>() ).value()->at( 0 );
             auto limits
               = handle::extract<ValueTree>( rlimits ).and_then( [&]( auto x ) { return relater_.get().get( x ); } );
 
-            return { limits.and_then( [&]( auto x ) { return handle::extract<Literal>( x->at( 1 ) ); } )
+            auto curr_output_size
+              = limits.and_then( [&]( auto x ) { return handle::extract<Literal>( x->at( 1 ) ); } )
+                  .transform( [&]( auto x ) { return uint64_t( x ); } )
+                  .value_or( output_size );
+            auto curr_fan_out
+              = max( limits.and_then( [&]( auto x ) { return handle::extract<Literal>( x->at( 2 ) ); } )
                        .transform( [&]( auto x ) { return uint64_t( x ); } )
-                       .value_or( output_size ),
-                     max( limits.and_then( [&]( auto x ) { return handle::extract<Literal>( x->at( 2 ) ); } )
-                            .transform( [&]( auto x ) { return uint64_t( x ); } )
-                            .value_or( output_fan_out ),
-                          output_fan_out ) };
+                       .value_or( output_fan_out ),
+                     output_fan_out );
+            bool ep = limits
+                        .transform( [&]( auto x ) -> bool {
+                          return ( x->size() > 3 ) ? handle::extract<Literal>( x->at( 3 ) )
+                                                       .transform( [&]( auto x ) { return uint8_t( x ); } )
+                                                       .value_or( 0 )
+                                                   : false;
+                        } )
+                        .value_or( false );
+
+            if ( ep ) {
+              if ( ( output_size - input_size ) > 20 * curr_output_size ) {
+                ep = false;
+              }
+            }
+
+            return { curr_output_size, curr_fan_out, ep };
           } else {
-            return { output_size, output_fan_out };
+            return { output_size, output_fan_out, false };
           }
         },
-        [&]( Handle<Identification> ) -> pair<size_t, size_t> {
+        [&]( Handle<Identification> ) -> tuple<size_t, size_t, bool> {
           if ( dependencies.size() == 0 ) {
             VLOG( 3 ) << "Dependency preresolved";
-            return { output_size, 1 };
+            return { output_size, 1, false };
           }
           if ( !tasks_info_.contains( *dependencies.begin() ) ) {
             throw std::runtime_error( "Task info does not contain dependency" );
           }
           auto out = tasks_info_.at( *dependencies.begin() ).output_size;
-          return { out, 1 };
+          return { out, 1, false };
         },
-        [&]( Handle<Selection> ) -> pair<size_t, size_t> { throw std::runtime_error( "Unimplemented" ); } } );
+        [&]( Handle<Selection> ) -> tuple<size_t, size_t, bool> {
+          throw std::runtime_error( "Unimplemented" );
+        } } );
     },
-    [&]( auto ) -> pair<size_t, size_t> {
-      return { output_size, output_fan_out };
+    [&]( auto ) -> tuple<size_t, size_t, bool> {
+      return { output_size, output_fan_out, false };
     } } );
 
-  tasks_info_[job].output_size = outs.first;
-  tasks_info_[job].output_fan_out = outs.second;
+  tasks_info_[job].output_size = get<0>( outs );
+  tasks_info_[job].output_fan_out = get<1>( outs );
+  tasks_info_[job].ep = get<2>( outs );
 }
 
 size_t BasePass::absent_size( std::shared_ptr<IRuntime> worker, Handle<AnyDataType> job )
@@ -280,13 +307,19 @@ void MinAbsentMaxParallelism::post( Handle<AnyDataType> job,
 {
   optional<shared_ptr<IRuntime>> chosen_remote;
 
-  job.visit<void>( overload { [&]( Handle<Relation> r ) {
-                               const auto& contains = base_.get().get_contains( r );
-                               if ( !contains.empty() ) {
-                                 chosen_remote = *contains.begin();
-                               }
-                             },
-                              []( auto ) {} } );
+  if ( base_.get().get_ep( job ) ) {
+    chosen_remote = relater_.get().get_local();
+  }
+
+  if ( !chosen_remote.has_value() ) {
+    job.visit<void>( overload { [&]( Handle<Relation> r ) {
+                                 const auto& contains = base_.get().get_contains( r );
+                                 if ( !contains.empty() ) {
+                                   chosen_remote = *contains.begin();
+                                 }
+                               },
+                                []( auto ) {} } );
+  }
 
   if ( !chosen_remote.has_value() ) {
     absl::flat_hash_map<shared_ptr<IRuntime>, size_t> present_output;
@@ -415,8 +448,18 @@ void ChildBackProp::pre( Handle<AnyDataType> job, const absl::flat_hash_set<Hand
   }
 }
 
-void OutSource::pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& dependencies )
+void InOutSource::pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& dependencies )
 {
+  bool any_ep = false;
+  for ( auto d : dependencies ) {
+    if ( base_.get().get_ep( d ) ) {
+      chosen_remotes_.at( d ) = { relater_.get().get_local(), 0 };
+      any_ep = true;
+    }
+  }
+  if ( any_ep )
+    return;
+
   size_t assigned = 0;
   multimap<int64_t, Handle<AnyDataType>, greater<int64_t>> scores;
   optional<shared_ptr<IRuntime>> local;
@@ -555,9 +598,9 @@ void PassRunner::run( reference_wrapper<Relater> rt, Handle<AnyDataType> top_lev
         break;
       }
 
-      case PassType::OutSource: {
+      case PassType::InOutSource: {
         if ( selection.has_value() ) {
-          selection = make_unique<OutSource>( base, rt, move( selection.value() ) );
+          selection = make_unique<InOutSource>( base, rt, move( selection.value() ), to_sends );
         } else {
           throw runtime_error( "Invalid pass sequence." );
         }

--- a/src/runtime/pass.cc
+++ b/src/runtime/pass.cc
@@ -596,8 +596,10 @@ void SendToRemotePass::pre( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDa
 
 void SendToRemotePass::send_job_dependencies( shared_ptr<IRuntime> rt, Handle<AnyDataType> job )
 {
-  auto remote_contained = job.visit<bool>(
-    overload { []( Handle<Literal> ) { return true; }, [&]( auto x ) { return rt->contains( x ); } } );
+  auto remote_contained = job.visit<bool>( overload { []( Handle<Literal> ) { return true; },
+                                                      [&]( Handle<Relation> x ) { return rt->contains( x ); },
+                                                      // Leave whether to send data to not to Remote's decision
+                                                      []( auto ) { return false; } } );
 
   if ( remote_contained ) {
     return;

--- a/src/runtime/pass.cc
+++ b/src/runtime/pass.cc
@@ -413,7 +413,7 @@ void ChildBackProp::independent( Handle<AnyDataType> job )
       // How much current choice is better than other choices (the smaller the better)
       auto prev = chosen_remotes_.at( job ).second;
 
-      if ( prev + curr_output_size < 0 ) {
+      if ( prev + static_cast<int64_t>( curr_output_size ) < 0 ) {
         return;
       }
 

--- a/src/runtime/pass.cc
+++ b/src/runtime/pass.cc
@@ -322,10 +322,6 @@ void MinAbsentMaxParallelism::post( Handle<Eval> job, const absl::flat_hash_set<
 {
   optional<shared_ptr<IRuntime>> chosen_remote;
 
-  if ( must_be_local_.contains( job ) ) {
-    chosen_remote = relater_.get().get_local();
-  }
-
   if ( base_.get().get_ep( job ) ) {
     chosen_remote = relater_.get().get_local();
   }
@@ -538,11 +534,6 @@ void InOutSource::pre( Handle<Eval> job, const absl::flat_hash_set<Handle<AnyDat
     // Collect available remotes
     std::vector<shared_ptr<IRuntime>> available_remotes;
     for ( auto d : dependencies ) {
-      if ( d.visit<bool>( overload { []( Handle<Relation> r ) { return must_be_local_.contains( r ); },
-                                     []( auto ) { return false; } } ) ) {
-        continue;
-      }
-
       const auto& absent_size = base_.get().get_absent_size( d );
       for ( const auto& [r, _] : absent_size ) {
         if ( is_local( r ) )

--- a/src/runtime/pass.hh
+++ b/src/runtime/pass.hh
@@ -145,32 +145,8 @@ public:
   {}
 };
 
-class SendtoRemote : public SelectionPass
-{
-  std::shared_ptr<IRuntime> target_remote_;
-  absl::flat_hash_set<Handle<AnyDataType>>& to_send_;
-
-  virtual void independent( Handle<AnyDataType> ) override {};
-  virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {};
-  virtual void post( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {};
-
-  virtual void leaf( Handle<AnyDataType> ) override;
-
-public:
-  SendtoRemote( std::reference_wrapper<BasePass> base,
-                std::reference_wrapper<Relater> relater,
-                std::shared_ptr<IRuntime> target_remote,
-                absl::flat_hash_set<Handle<AnyDataType>>& to_send )
-    : SelectionPass( base, relater )
-    , target_remote_( target_remote )
-    , to_send_( to_send )
-  {}
-};
-
 class OutSource : public PrunedSelectionPass
 {
-  std::map<std::shared_ptr<IRuntime>, absl::flat_hash_set<Handle<AnyDataType>>>& to_sends_;
-
   virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
 
   virtual void leaf( Handle<AnyDataType> ) override {}
@@ -180,10 +156,8 @@ class OutSource : public PrunedSelectionPass
 public:
   OutSource( std::reference_wrapper<BasePass> base,
              std::reference_wrapper<Relater> relater,
-             std::unique_ptr<SelectionPass> prev,
-             std::map<std::shared_ptr<IRuntime>, absl::flat_hash_set<Handle<AnyDataType>>>& to_sends )
+             std::unique_ptr<SelectionPass> prev )
     : PrunedSelectionPass( base, relater, move( prev ) )
-    , to_sends_( to_sends )
   {}
 };
 

--- a/src/runtime/pass.hh
+++ b/src/runtime/pass.hh
@@ -22,9 +22,9 @@ protected:
   // Function to be executed on every leaf of the dependency graph.
   virtual void leaf( Handle<AnyDataType> ) = 0;
   // Function to be executed on every depender before recurse into its dependees
-  virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) = 0;
+  virtual void pre( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) = 0;
   // Function to be executed on every depender after recurse into its dependees
-  virtual void post( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) = 0;
+  virtual void post( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) = 0;
 
 public:
   Pass( std::reference_wrapper<Relater> relater );
@@ -48,9 +48,9 @@ private:
 
   virtual void leaf( Handle<AnyDataType> ) override;
   virtual void independent( Handle<AnyDataType> ) override;
-  virtual void post( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
+  virtual void post( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
 
-  virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
+  virtual void pre( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
 
   // Calculate absent size from a root
   size_t absent_size( std::shared_ptr<IRuntime> worker, Handle<AnyDataType> job );
@@ -109,10 +109,10 @@ public:
 class MinAbsentMaxParallelism : public SelectionPass
 {
   virtual void leaf( Handle<AnyDataType> ) override;
-  virtual void post( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
+  virtual void post( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
 
   virtual void independent( Handle<AnyDataType> ) override {};
-  virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
+  virtual void pre( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
 
 public:
   MinAbsentMaxParallelism( std::reference_wrapper<BasePass> base, std::reference_wrapper<Relater> relater )
@@ -131,10 +131,10 @@ class ChildBackProp : public SelectionPass
   absl::flat_hash_map<Handle<AnyDataType>, absl::flat_hash_set<Handle<AnyDataType>>> dependees_ {};
 
   virtual void independent( Handle<AnyDataType> ) override;
-  virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
+  virtual void pre( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
 
   virtual void leaf( Handle<AnyDataType> ) override {}
-  virtual void post( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
+  virtual void post( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
 
 public:
   ChildBackProp( std::reference_wrapper<BasePass> base, std::reference_wrapper<Relater> relater )
@@ -150,11 +150,11 @@ public:
 
 class InOutSource : public PrunedSelectionPass
 {
-  virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
+  virtual void pre( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
 
   virtual void leaf( Handle<AnyDataType> ) override {}
   virtual void independent( Handle<AnyDataType> ) override {};
-  virtual void post( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
+  virtual void post( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
 
 public:
   InOutSource( std::reference_wrapper<BasePass> base,
@@ -166,9 +166,9 @@ public:
 
 class RandomSelection : public SelectionPass
 {
-  virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
+  virtual void pre( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
   virtual void leaf( Handle<AnyDataType> ) override {}
-  virtual void post( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
+  virtual void post( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
 
   virtual void independent( Handle<AnyDataType> ) override;
 
@@ -183,10 +183,10 @@ class FinalPass : public PrunedSelectionPass
   std::unordered_map<std::shared_ptr<IRuntime>, absl::flat_hash_set<Handle<AnyDataType>>> remote_jobs_ {};
 
   virtual void leaf( Handle<AnyDataType> ) override;
-  virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
+  virtual void pre( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
   virtual void independent( Handle<AnyDataType> ) override;
 
-  virtual void post( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
+  virtual void post( Handle<Eval>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
 
 public:
   FinalPass( std::reference_wrapper<BasePass> base,

--- a/src/runtime/pass.hh
+++ b/src/runtime/pass.hh
@@ -222,6 +222,8 @@ public:
   {
     return remote_jobs_;
   };
+
+  void make_root_local( Handle<AnyDataType> );
 };
 
 // A correct sequence of passes contains: BasePass + (n >= 1) * SelectionPass + (n >= 0) * PrunedSelectionPass +

--- a/src/runtime/pass.hh
+++ b/src/runtime/pass.hh
@@ -41,6 +41,7 @@ private:
     std::unordered_set<std::shared_ptr<IRuntime>> contains {};
     size_t output_size {};
     size_t output_fan_out {};
+    bool ep { false };
   };
 
   absl::flat_hash_map<Handle<AnyDataType>, TaskInfo> tasks_info_ {};
@@ -71,6 +72,8 @@ public:
   size_t get_output_size( const Handle<AnyDataType> task ) const { return tasks_info_.at( task ).output_size; }
 
   size_t get_fan_out( const Handle<AnyDataType> task ) const { return tasks_info_.at( task ).output_fan_out; }
+
+  bool get_ep( const Handle<AnyDataType> task ) const { return tasks_info_.at( task ).ep; }
 };
 
 class SelectionPass : public Pass
@@ -145,7 +148,7 @@ public:
   {}
 };
 
-class OutSource : public PrunedSelectionPass
+class InOutSource : public PrunedSelectionPass
 {
   virtual void pre( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override;
 
@@ -154,9 +157,9 @@ class OutSource : public PrunedSelectionPass
   virtual void post( Handle<AnyDataType>, const absl::flat_hash_set<Handle<AnyDataType>>& ) override {}
 
 public:
-  OutSource( std::reference_wrapper<BasePass> base,
-             std::reference_wrapper<Relater> relater,
-             std::unique_ptr<SelectionPass> prev )
+  InOutSource( std::reference_wrapper<BasePass> base,
+               std::reference_wrapper<Relater> relater,
+               std::unique_ptr<SelectionPass> prev )
     : PrunedSelectionPass( base, relater, move( prev ) )
   {}
 };
@@ -209,7 +212,7 @@ public:
   {
     MinAbsentMaxParallelism,
     ChildBackProp,
-    OutSource,
+    InOutSource,
     Random
   };
 

--- a/src/runtime/pass.hh
+++ b/src/runtime/pass.hh
@@ -199,8 +199,6 @@ public:
   {
     return remote_jobs_;
   };
-
-  void make_root_local( Handle<AnyDataType> );
 };
 
 // A correct sequence of passes contains: BasePass + (n >= 1) * SelectionPass + (n >= 0) * PrunedSelectionPass +

--- a/src/runtime/relater.cc
+++ b/src/runtime/relater.cc
@@ -355,12 +355,25 @@ optional<Handle<Object>> Relater::get( Handle<Relation> name )
     return storage_.get( name );
   }
 
-  auto works = relate( name );
-  if ( !works.empty() ) {
-    scheduler_->schedule( works, name );
+  if ( local_->get_info()->parallelism == 0 ) {
+    auto locked_remotes = remotes_.read();
+    if ( locked_remotes->size() > 0 ) {
+      for ( const auto& remote : locked_remotes.get() ) {
+        auto locked_remote = remote.lock();
+        if ( locked_remote ) {
+          locked_remote->get( name );
+        }
+      }
+    }
     return {};
   } else {
-    return storage_.get( name );
+    auto works = relate( name );
+    if ( !works.empty() ) {
+      scheduler_->schedule( works, name );
+      return {};
+    } else {
+      return storage_.get( name );
+    }
   }
 }
 

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -9,8 +9,6 @@
 inline thread_local std::vector<Handle<AnyDataType>> works_;
 inline thread_local Handle<Relation> current_;
 inline thread_local DependencyGraph sketch_graph_;
-inline thread_local absl::flat_hash_set<Handle<Relation>> must_be_local_;
-inline thread_local bool replaced_;
 
 class Executor;
 class Scheduler;

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -173,7 +173,8 @@ public:
   {
     return graph_.read()->get_forward_dependencies( blocked );
   }
-  virtual void erase_backward_dependencies ( Handle<Relation> blocked ) override {
+  virtual void erase_backward_dependencies( Handle<Relation> blocked ) override
+  {
     graph_.write()->erase_backward_dependencies( blocked );
   }
 

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -167,4 +167,11 @@ public:
 
   Repository& get_repository() { return repository_; }
   virtual std::unordered_set<Handle<AnyDataType>> data() const override { return repository_.data(); }
+  virtual absl::flat_hash_set<Handle<AnyDataType>> get_forward_dependencies( Handle<Relation> blocked ) override
+  {
+    return graph_.read()->get_forward_dependencies( blocked );
+  }
+  virtual void erase_backward_dependencies ( Handle<Relation> blocked ) override {
+    graph_.write()->erase_backward_dependencies( blocked );
+  }
 };

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -174,4 +174,6 @@ public:
   virtual void erase_backward_dependencies ( Handle<Relation> blocked ) override {
     graph_.write()->erase_backward_dependencies( blocked );
   }
+
+  std::shared_ptr<IRuntime> get_local() { return local_; }
 };

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -12,6 +12,7 @@ inline thread_local std::optional<Handle<Relation>> current_;
 class Executor;
 class Scheduler;
 class LocalFirstScheduler;
+class HintScheduler;
 class Pass;
 class BasePass;
 class PrunedSelectionPass;
@@ -22,6 +23,7 @@ class Relater
 {
   friend class Executor;
   friend class LocalFirstScheduler;
+  friend class HintScheduler;
   friend class Pass;
   friend class BasePass;
   friend class PrunedSelectionPass;

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -12,7 +12,6 @@ inline thread_local DependencyGraph sketch_graph_;
 
 class Executor;
 class Scheduler;
-class LocalFirstScheduler;
 class HintScheduler;
 class BasePass;
 class RelaterTest;
@@ -22,7 +21,6 @@ class Relater
   , FixRuntime
 {
   friend class Executor;
-  friend class LocalFirstScheduler;
   friend class HintScheduler;
   friend class BasePass;
   friend class RelaterTest;

--- a/src/runtime/relater.hh
+++ b/src/runtime/relater.hh
@@ -7,7 +7,9 @@
 #include "runner.hh"
 
 inline thread_local std::vector<Handle<AnyDataType>> works_;
-inline thread_local std::optional<Handle<Relation>> current_;
+inline thread_local Handle<Relation> current_;
+inline thread_local absl::flat_hash_set<Handle<Relation>> must_be_local_;
+inline thread_local bool replaced_;
 
 class Executor;
 class Scheduler;
@@ -16,6 +18,7 @@ class HintScheduler;
 class Pass;
 class BasePass;
 class PrunedSelectionPass;
+class RelaterTest;
 
 class Relater
   : public MultiWorkerRuntime
@@ -27,6 +30,7 @@ class Relater
   friend class Pass;
   friend class BasePass;
   friend class PrunedSelectionPass;
+  friend class RelaterTest;
 
 private:
   SharedMutex<DependencyGraph> graph_ {};

--- a/src/runtime/runtimes.cc
+++ b/src/runtime/runtimes.cc
@@ -25,12 +25,14 @@ Handle<Value> ReadWriteRT::execute( Handle<Relation> x )
   auto res = relater_.execute( x );
 
   relater_.visit_full( x, [this]( Handle<AnyDataType> h ) {
-    h.visit<void>( overload { []( Handle<Literal> ) {},
-                              [&]( auto handle ) {
-                                auto& repo = relater_.get_repository();
-                                if ( not repo.contains( handle ) )
-                                  repo.put( handle, relater_.get( handle ).value() );
-                              } } );
+    h.visit<void>( overload {
+      []( Handle<Literal> ) {},
+      [&]( auto handle ) {
+        auto& repo = relater_.get_repository();
+        if ( not repo.contains( handle ) )
+          repo.put( handle, relater_.get( handle ).value() );
+      },
+    } );
   } );
   return res;
 }

--- a/src/runtime/runtimes.hh
+++ b/src/runtime/runtimes.hh
@@ -59,7 +59,7 @@ protected:
 
 public:
   Server( std::shared_ptr<Scheduler> scheduler )
-    : relater_( std::thread::hardware_concurrency(), {}, scheduler )
+    : relater_( std::thread::hardware_concurrency() - 1, {}, scheduler )
   {}
 
   static std::shared_ptr<Server> init( const Address& address,

--- a/src/runtime/scheduler.cc
+++ b/src/runtime/scheduler.cc
@@ -69,7 +69,7 @@ void HintScheduler::schedule( vector<Handle<AnyDataType>>& leaf_jobs, Handle<Rel
                    top_level_job,
                    { PassRunner::PassType::MinAbsentMaxParallelism,
                      // PassRunner::PassType::ChildBackProp,
-                     PassRunner::PassType::OutSource } );
+                     PassRunner::PassType::InOutSource } );
 }
 
 void RandomScheduler::schedule( vector<Handle<AnyDataType>>& leaf_jobs, Handle<Relation> top_level_job )

--- a/src/runtime/scheduler.cc
+++ b/src/runtime/scheduler.cc
@@ -22,12 +22,15 @@ void Scheduler::merge_sketch_graph( Handle<Relation> job, absl::flat_hash_set<Ha
   }
 
   for ( auto d : relater_.value().get().get_forward_dependencies( job ) ) {
-    d.visit<void>( overload { [&]( Handle<Relation> r ) {
-                               r.visit<void>(
-                                 overload { [&]( Handle<Eval> e ) { merge_sketch_graph( e, unblocked ); },
-                                            []( Handle<Apply> ) {} } );
-                             },
-                              []( auto ) {} } );
+    d.visit<void>( overload {
+      [&]( Handle<Relation> r ) {
+        r.visit<void>( overload {
+          [&]( Handle<Eval> e ) { merge_sketch_graph( e, unblocked ); },
+          []( Handle<Apply> ) {},
+        } );
+      },
+      []( auto ) {},
+    } );
   }
 }
 

--- a/src/runtime/scheduler.cc
+++ b/src/runtime/scheduler.cc
@@ -110,7 +110,7 @@ void HintScheduler::schedule( vector<Handle<AnyDataType>>& leaf_jobs, Handle<Rel
   PassRunner::run( relater_.value(),
                    top_level_job,
                    { PassRunner::PassType::MinAbsentMaxParallelism,
-                     // PassRunner::PassType::ChildBackProp,
+                     PassRunner::PassType::ChildBackProp,
                      PassRunner::PassType::InOutSource } );
 }
 

--- a/src/runtime/scheduler.cc
+++ b/src/runtime/scheduler.cc
@@ -16,50 +16,17 @@ bool is_local( shared_ptr<IRuntime> rt )
 {
   return rt->get_info()->link_speed == numeric_limits<double>::max();
 }
-
-void get( shared_ptr<IRuntime> worker, Handle<AnyDataType> job, Relater& rt )
-{
-  if ( is_local( worker ) ) {
-    job.visit<void>( overload {
-      [&]( Handle<Literal> ) {},
-      [&]( auto h ) { worker->get( h ); },
-    } );
-  } else {
-    // Send visit( job ) before sending the job itself
-    auto send = [&]( Handle<AnyDataType> h ) {
-      h.visit<void>( overload { []( Handle<Literal> ) {},
-                                []( Handle<Relation> ) {},
-                                [&]( auto x ) { worker->put( x, rt.get( x ).value() ); } } );
-    };
-
-    job.visit<void>( overload {
-      [&]( Handle<Relation> r ) {
-        rt.visit( r.visit<Handle<Fix>>( overload { []( Handle<Apply> a ) { return a.unwrap<ObjectTree>(); },
-                                                   []( Handle<Eval> e ) {
-                                                     auto obj = e.unwrap<Object>();
-                                                     return handle::extract<Thunk>( obj )
-                                                       .transform( []( auto obj ) -> Handle<Fix> {
-                                                         return Handle<Strict>( obj );
-                                                       } )
-                                                       .or_else( [&]() -> optional<Handle<Fix>> { return obj; } )
-                                                       .value();
-                                                   } } ),
-                  send );
-      },
-      []( auto ) {} } );
-
-    job.visit<void>( overload { []( Handle<Literal> ) { throw runtime_error( "Unreachable" ); },
-                                [&]( auto h ) { worker->get( h ); } } );
-  }
-}
 }
 
 void LocalFirstScheduler::schedule( vector<Handle<AnyDataType>>& leaf_jobs, Handle<Relation> top_level_job )
 {
   auto local = relater_.value().get().local_;
   if ( local->get_info()->parallelism > 0 ) {
-    for ( const auto& leaf_job : leaf_jobs ) {
-      scheduler::get( local, leaf_job, relater_->get() );
+    for ( auto leaf_job : leaf_jobs ) {
+      leaf_job.visit<void>( overload {
+        [&]( Handle<Literal> ) {},
+        [&]( auto h ) { local->get( h ); },
+      } );
     }
     return;
   }
@@ -102,7 +69,7 @@ void HintScheduler::schedule( vector<Handle<AnyDataType>>& leaf_jobs, Handle<Rel
   PassRunner::run( relater_.value(),
                    top_level_job,
                    { PassRunner::PassType::MinAbsentMaxParallelism,
-                     PassRunner::PassType::ChildBackProp,
+                     // PassRunner::PassType::ChildBackProp,
                      PassRunner::PassType::OutSource } );
 }
 

--- a/src/runtime/scheduler.cc
+++ b/src/runtime/scheduler.cc
@@ -65,6 +65,17 @@ void HintScheduler::schedule( vector<Handle<AnyDataType>>& leaf_jobs, Handle<Rel
     return;
   }
 
+  if ( relater_->get().remotes_.read()->size() == 0 ) {
+    for ( auto leaf_job : leaf_jobs ) {
+      leaf_job.visit<void>( overload {
+        [&]( Handle<Literal> ) {},
+        [&]( auto h ) { relater_->get().local_->get( h ); },
+      } );
+
+      return;
+    }
+  }
+
   PassRunner::run( relater_.value(),
                    top_level_job,
                    { PassRunner::PassType::MinAbsentMaxParallelism,

--- a/src/runtime/scheduler.cc
+++ b/src/runtime/scheduler.cc
@@ -1,6 +1,5 @@
 #include "scheduler.hh"
 #include "handle.hh"
-#include "handle_post.hh"
 #include "overload.hh"
 #include "pass.hh"
 #include "storage_exception.hh"
@@ -36,7 +35,7 @@ void LocalFirstScheduler::schedule( vector<Handle<AnyDataType>>& leaf_jobs, Hand
     for ( const auto& remote : locked_remotes.get() ) {
       auto locked_remote = remote.lock();
       if ( locked_remote ) {
-        scheduler::get( locked_remote, top_level_job, relater_->get() );
+        locked_remote->get( top_level_job );
         return;
       }
     }

--- a/src/runtime/scheduler.hh
+++ b/src/runtime/scheduler.hh
@@ -27,12 +27,6 @@ public:
   virtual ~Scheduler() {};
 };
 
-class LocalFirstScheduler : public Scheduler
-{
-public:
-  virtual void schedule( std::vector<Handle<AnyDataType>>& leaf_jobs, Handle<Relation> top_level_job ) override;
-};
-
 class OnePassScheduler : public Scheduler
 {
 public:

--- a/src/runtime/scheduler.hh
+++ b/src/runtime/scheduler.hh
@@ -7,6 +7,7 @@ class Scheduler
 {
 protected:
   std::optional<std::reference_wrapper<Relater>> relater_ {};
+  void merge_sketch_graph( Handle<Relation> job, absl::flat_hash_set<Handle<Relation>>& unblocked );
 
 public:
   /*

--- a/src/storage/handle_util.hh
+++ b/src/storage/handle_util.hh
@@ -1,6 +1,5 @@
 #pragma once
 #include <cwchar>
-#include <iostream>
 #include <string_view>
 
 #include "blake3.hh"
@@ -85,25 +84,12 @@ struct any_tree_equal
 namespace job {
 static inline Handle<Fix> get_root( Handle<AnyDataType> job )
 {
-  return job.visit<Handle<Fix>>( overload {
-    [&]( Handle<Relation> r ) {
-      return r.visit<Handle<Fix>>( overload {
-
-        [&]( Handle<Apply> a ) { return a.unwrap<ObjectTree>(); },
-        [&]( Handle<Eval> e ) {
-          return e.unwrap<Object>().visit<Handle<Fix>>( overload {
-            []( Handle<Thunk> t ) {
-              return t.visit<Handle<Fix>>( overload {
-                []( Handle<Application> a ) { return a.unwrap<ExpressionTree>(); },
-                []( Handle<Identification> i ) { return i.unwrap<Value>(); },
-                []( Handle<Selection> ) -> Handle<Fix> { throw std::runtime_error( "Unimplemented" ); } } );
-            },
-            []( auto h ) { return h; }
-
-          } );
-        } } );
-    },
-    [&]( Handle<AnyTree> h ) { return handle::fix( h ); },
-    [&]( auto h ) { return h; } } );
+  return job.visit<Handle<Fix>>( overload { [&]( Handle<Relation> r ) {
+                                             return r.visit<Handle<Fix>>(
+                                               overload { [&]( Handle<Apply> a ) { return a.unwrap<ObjectTree>(); },
+                                                          [&]( Handle<Eval> e ) { return e.unwrap<Object>(); } } );
+                                           },
+                                            [&]( Handle<AnyTree> h ) { return handle::fix( h ); },
+                                            [&]( auto h ) { return h; } } );
 }
 }

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -214,7 +214,7 @@ public:
   // Return the list of forward dependencies
   virtual absl::flat_hash_set<Handle<AnyDataType>> get_forward_dependencies( Handle<Relation> ) { return {}; }
   // Make task only unblock by finishing itself
-  virtual void erase_backward_dependencies ( Handle<Relation> ) {}
+  virtual void erase_backward_dependencies( Handle<Relation> ) {}
 
   virtual bool reply_to_contains( Handle<Relation> ) { return false; }
 };

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -213,8 +213,6 @@ public:
   virtual std::unordered_set<Handle<AnyDataType>> data() const { return {}; };
   // Return the list of forward dependencies
   virtual absl::flat_hash_set<Handle<AnyDataType>> get_forward_dependencies( Handle<Relation> ) { return {}; }
-  // Make task only unblock by finishing itself
-  virtual void erase_backward_dependencies( Handle<Relation> ) {}
 };
 
 class MultiWorkerRuntime : public IRuntime

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -5,6 +5,8 @@
 #include "object.hh"
 #include "overload.hh"
 #include "types.hh"
+
+#include <absl/container/flat_hash_set.h>
 #include <functional>
 #include <glog/logging.h>
 #include <unordered_set>
@@ -209,6 +211,10 @@ public:
 
   // Return the list of data presening in .fix repository
   virtual std::unordered_set<Handle<AnyDataType>> data() const { return {}; };
+  // Return the list of forward dependencies
+  virtual absl::flat_hash_set<Handle<AnyDataType>> get_forward_dependencies( Handle<Relation> ) { return {}; }
+  // Make task only unblock by finishing itself
+  virtual void erase_backward_dependencies ( Handle<Relation> ) {}
 };
 
 class MultiWorkerRuntime : public IRuntime

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -215,8 +215,6 @@ public:
   virtual absl::flat_hash_set<Handle<AnyDataType>> get_forward_dependencies( Handle<Relation> ) { return {}; }
   // Make task only unblock by finishing itself
   virtual void erase_backward_dependencies( Handle<Relation> ) {}
-
-  virtual bool reply_to_contains( Handle<Relation> ) { return false; }
 };
 
 class MultiWorkerRuntime : public IRuntime

--- a/src/storage/interface.hh
+++ b/src/storage/interface.hh
@@ -215,6 +215,8 @@ public:
   virtual absl::flat_hash_set<Handle<AnyDataType>> get_forward_dependencies( Handle<Relation> ) { return {}; }
   // Make task only unblock by finishing itself
   virtual void erase_backward_dependencies ( Handle<Relation> ) {}
+
+  virtual bool reply_to_contains( Handle<Relation> ) { return false; }
 };
 
 class MultiWorkerRuntime : public IRuntime

--- a/src/storage/repository.cc
+++ b/src/storage/repository.cc
@@ -313,7 +313,7 @@ bool Repository::contains( Handle<Fix> handle )
 bool Repository::contains( const std::string_view label )
 {
   try {
-    return fs::exists( repo_ / "labels" / label );
+    return fs::is_symlink( repo_ / "labels" / label );
   } catch ( fs::filesystem_error& ) {
     throw RepositoryCorrupt( repo_ );
   }

--- a/src/tester/CMakeLists.txt
+++ b/src/tester/CMakeLists.txt
@@ -13,5 +13,8 @@ target_link_libraries(fixpoint-client runtime)
 add_executable(fixpoint-client-wikipedia "fixpoint-client-wikipedia.cc" "tester-utils.cc")
 target_link_libraries(fixpoint-client-wikipedia runtime)
 
+add_executable(fixpoint-client-compile "fixpoint-client-compile.cc" "tester-utils.cc")
+target_link_libraries(fixpoint-client-compile runtime)
+
 # add_executable(http-tester "http-tester.cc" "main.cc" "tester-utils.cc")
 # target_link_libraries(http-tester runtime http)

--- a/src/tester/fixpoint-client-compile.cc
+++ b/src/tester/fixpoint-client-compile.cc
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <unistd.h>
+
+#include "handle.hh"
+#include "runtimes.hh"
+#include "tester-utils.hh"
+#include "types.hh"
+
+using namespace std;
+
+int main( int argc, char* argv[] )
+{
+  std::shared_ptr<Client> rt;
+
+  if ( argc != 3 )
+    cerr << "Usage: +[address]:[port] [label-to-compile]" << endl;
+
+  if ( argv[1][0] == '+' ) {
+    string addr( &argv[1][1] );
+    if ( addr.find( ':' ) == string::npos ) {
+      throw runtime_error( "invalid argument " + addr );
+    }
+    Address address( addr.substr( 0, addr.find( ':' ) ), stoi( addr.substr( addr.find( ':' ) + 1 ) ) );
+    rt = Client::init( address );
+  } else {
+    exit( 1 );
+  }
+
+  auto compile_encode = rt->get_rt()
+                          .labeled( "compile-encode" )
+                          .unwrap<Expression>()
+                          .unwrap<Object>()
+                          .unwrap<Value>()
+                          .unwrap<ValueTree>();
+  rt->get_rt().get( compile_encode );
+
+  auto target = Handle<Strict>( Handle<Identification>(
+    rt->get_rt().labeled( argv[2] ).unwrap<Expression>().unwrap<Object>().unwrap<Value>() ) );
+
+  auto application = OwnedMutTree::allocate( 3 );
+  application[0] = make_limits( rt->get_rt(), 1024 * 1024 * 1024, 1024 * 1024, 1 );
+  application[1] = compile_encode;
+  application[2] = target;
+
+  auto handle = rt->get_rt().create( make_shared<OwnedTree>( std::move( application ) ) ).unwrap<ValueTree>();
+
+  auto res = rt->execute( Handle<Eval>( Handle<Object>( Handle<Application>( handle::upcast( handle ) ) ) ) );
+
+  // print the result
+  cout << "Result:\n" << res << endl;
+
+  return 0;
+}

--- a/src/tester/fixpoint-server.cc
+++ b/src/tester/fixpoint-server.cc
@@ -60,9 +60,9 @@ int main( int argc, char* argv[] )
       peerfile = argument;
     } );
   parser.AddOption(
-    's', "scheduler", "scheduler", "Scheduler to use [local, onepass, hint, random]", [&]( const char* argument ) {
+    's', "scheduler", "scheduler", "Scheduler to use [onepass, hint, random]", [&]( const char* argument ) {
       sche_opt = argument;
-      if ( not( *sche_opt == "local" or *sche_opt == "onepass" or *sche_opt == "hint" or *sche_opt == "random" ) ) {
+      if ( not( *sche_opt == "onepass" or *sche_opt == "hint" or *sche_opt == "random" ) ) {
         throw runtime_error( "Invalid scheduler: " + sche_opt.value() );
       }
     } );
@@ -95,7 +95,7 @@ int main( int argc, char* argv[] )
     }
   }
 
-  shared_ptr<Scheduler> scheduler = make_shared<LocalFirstScheduler>();
+  shared_ptr<Scheduler> scheduler = make_shared<HintScheduler>();
   if ( sche_opt.has_value() ) {
     if ( *sche_opt == "onepass" ) {
       scheduler = make_shared<OnePassScheduler>();

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(test-evaluator runtime)
 add_executable(test-executor test-executor.cc main.cc)
 target_link_libraries(test-executor runtime)
 
+add_executable(test-relater test-relater.cc main.cc)
+target_link_libraries(test-relater runtime)
+
 add_executable(test-distributed test-distributed.cc main.cc)
 target_link_libraries(test-distributed runtime)
 

--- a/src/tests/test-relater.cc
+++ b/src/tests/test-relater.cc
@@ -38,17 +38,6 @@ void case0()
     fprintf( stderr, "Wrong leaf jobs" );
     exit( 1 );
   }
-
-  if ( must_be_local_.size() != 2 ) {
-    fprintf( stderr, "Wrong number of jobs that must happen locally" );
-    exit( 1 );
-  }
-
-  if ( !must_be_local_.contains( Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) )
-       || !must_be_local_.contains( Handle<Eval>( thunk0 ) ) ) {
-    fprintf( stderr, "Wrong jobs that must happen locally" );
-    exit( 1 );
-  }
 }
 
 void case1()
@@ -75,16 +64,6 @@ void case1()
     fprintf( stderr, "Wrong leaf jobs" );
     exit( 1 );
   }
-
-  if ( must_be_local_.size() != 1 ) {
-    fprintf( stderr, "Wrong number of jobs that must happen locally" );
-    exit( 1 );
-  }
-
-  if ( !must_be_local_.contains( Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) ) ) {
-    fprintf( stderr, "Wrong jobs that must happen locally" );
-    exit( 1 );
-  }
 }
 
 void case2()
@@ -109,11 +88,6 @@ void case2()
 
   if ( !( works_[0] == apply1 ) ) {
     fprintf( stderr, "Wrong leaf jobs" );
-    exit( 1 );
-  }
-
-  if ( must_be_local_.size() != 0 ) {
-    fprintf( stderr, "Wrong number of jobs that must happen locally" );
     exit( 1 );
   }
 }

--- a/src/tests/test-relater.cc
+++ b/src/tests/test-relater.cc
@@ -7,10 +7,7 @@ using namespace std;
 class RelaterTest
 {
 public:
-  static vector<Handle<AnyDataType>> relate( shared_ptr<Relater> rt, Handle<Relation> r )
-  {
-    return rt->relate( r );
-  }
+  static void relate( shared_ptr<Relater> rt, Handle<Relation> r ) { rt->relate( r ); }
 };
 
 void case0()
@@ -25,9 +22,9 @@ void case0()
            thunk1 );
   auto thunk_tree = tree( *rt, thunk0, thunk2 );
 
-  auto works = RelaterTest::relate( rt, Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) );
+  RelaterTest::relate( rt, Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) );
 
-  if ( works.size() != 2 ) {
+  if ( works_.size() != 2 ) {
     fprintf( stderr, "Wrong number of leaf jobs" );
     exit( 1 );
   }
@@ -37,7 +34,7 @@ void case0()
   auto apply2 = Handle<AnyDataType>( Handle<Relation>(
     Handle<Apply>( Handle<ObjectTree>( tree( *rt, Handle<Literal>( "two" ) ).unwrap<ValueTree>() ) ) ) );
 
-  if ( !( works[0] == apply1 && works[1] == apply2 ) && !( works[0] == apply2 && works[1] == apply1 ) ) {
+  if ( !( works_[0] == apply1 && works_[1] == apply2 ) && !( works_[0] == apply2 && works_[1] == apply1 ) ) {
     fprintf( stderr, "Wrong leaf jobs" );
     exit( 1 );
   }
@@ -64,9 +61,9 @@ void case1()
   rt->put( Handle<Eval>( thunk0 ), Handle<Literal>( "zero" ) );
   auto thunk_tree = tree( *rt, thunk0, thunk1 );
 
-  auto works = RelaterTest::relate( rt, Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) );
+  RelaterTest::relate( rt, Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) );
 
-  if ( works.size() != 1 ) {
+  if ( works_.size() != 1 ) {
     fprintf( stderr, "Wrong number of leaf jobs" );
     exit( 1 );
   }
@@ -74,7 +71,7 @@ void case1()
   auto apply1 = Handle<AnyDataType>( Handle<Relation>(
     Handle<Apply>( Handle<ObjectTree>( tree( *rt, Handle<Literal>( "one" ) ).unwrap<ValueTree>() ) ) ) );
 
-  if ( !( works[0] == apply1 ) ) {
+  if ( !( works_[0] == apply1 ) ) {
     fprintf( stderr, "Wrong leaf jobs" );
     exit( 1 );
   }
@@ -100,9 +97,9 @@ void case2()
   rt->put( Handle<Eval>( thunk0 ), Handle<Literal>( "zero" ) );
   auto thunk_tree = tree( *rt, thunk0, thunk1 );
 
-  auto works = RelaterTest::relate( rt, Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) );
+  RelaterTest::relate( rt, Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) );
 
-  if ( works.size() != 1 ) {
+  if ( works_.size() != 1 ) {
     fprintf( stderr, "Wrong number of leaf jobs" );
     exit( 1 );
   }
@@ -110,7 +107,7 @@ void case2()
   auto apply1 = Handle<AnyDataType>( Handle<Relation>(
     Handle<Apply>( Handle<ObjectTree>( tree( *rt, Handle<Literal>( "one" ) ).unwrap<ValueTree>() ) ) ) );
 
-  if ( !( works[0] == apply1 ) ) {
+  if ( !( works_[0] == apply1 ) ) {
     fprintf( stderr, "Wrong leaf jobs" );
     exit( 1 );
   }

--- a/src/tests/test-relater.cc
+++ b/src/tests/test-relater.cc
@@ -1,0 +1,129 @@
+#include "handle.hh"
+#include "relater.hh"
+#include "test.hh"
+
+using namespace std;
+
+class RelaterTest
+{
+public:
+  static vector<Handle<AnyDataType>> relate( shared_ptr<Relater> rt, Handle<Relation> r )
+  {
+    return rt->relate( r );
+  }
+};
+
+void case0()
+{
+  auto rt = make_shared<Relater>();
+
+  auto thunk0 = Handle<Application>( handle::upcast( tree( *rt, Handle<Literal>( "zero" ) ) ) );
+  auto thunk1 = Handle<Application>( handle::upcast( tree( *rt, Handle<Literal>( "one" ) ) ) );
+  auto thunk2 = Handle<Application>( handle::upcast( tree( *rt, Handle<Literal>( "two" ) ) ) );
+
+  rt->put( Handle<Apply>( Handle<ObjectTree>( tree( *rt, Handle<Literal>( "zero" ) ).unwrap<ValueTree>() ) ),
+           thunk1 );
+  auto thunk_tree = tree( *rt, thunk0, thunk2 );
+
+  auto works = RelaterTest::relate( rt, Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) );
+
+  if ( works.size() != 2 ) {
+    fprintf( stderr, "Wrong number of leaf jobs" );
+    exit( 1 );
+  }
+
+  auto apply1 = Handle<AnyDataType>( Handle<Relation>(
+    Handle<Apply>( Handle<ObjectTree>( tree( *rt, Handle<Literal>( "one" ) ).unwrap<ValueTree>() ) ) ) );
+  auto apply2 = Handle<AnyDataType>( Handle<Relation>(
+    Handle<Apply>( Handle<ObjectTree>( tree( *rt, Handle<Literal>( "two" ) ).unwrap<ValueTree>() ) ) ) );
+
+  if ( !( works[0] == apply1 && works[1] == apply2 ) && !( works[0] == apply2 && works[1] == apply1 ) ) {
+    fprintf( stderr, "Wrong leaf jobs" );
+    exit( 1 );
+  }
+
+  if ( must_be_local_.size() != 2 ) {
+    fprintf( stderr, "Wrong number of jobs that must happen locally" );
+    exit( 1 );
+  }
+
+  if ( !must_be_local_.contains( Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) )
+       || !must_be_local_.contains( Handle<Eval>( thunk0 ) ) ) {
+    fprintf( stderr, "Wrong jobs that must happen locally" );
+    exit( 1 );
+  }
+}
+
+void case1()
+{
+  auto rt = make_shared<Relater>();
+
+  auto thunk0 = Handle<Application>( handle::upcast( tree( *rt, Handle<Literal>( "zero" ) ) ) );
+  auto thunk1 = Handle<Application>( handle::upcast( tree( *rt, Handle<Literal>( "one" ) ) ) );
+
+  rt->put( Handle<Eval>( thunk0 ), Handle<Literal>( "zero" ) );
+  auto thunk_tree = tree( *rt, thunk0, thunk1 );
+
+  auto works = RelaterTest::relate( rt, Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) );
+
+  if ( works.size() != 1 ) {
+    fprintf( stderr, "Wrong number of leaf jobs" );
+    exit( 1 );
+  }
+
+  auto apply1 = Handle<AnyDataType>( Handle<Relation>(
+    Handle<Apply>( Handle<ObjectTree>( tree( *rt, Handle<Literal>( "one" ) ).unwrap<ValueTree>() ) ) ) );
+
+  if ( !( works[0] == apply1 ) ) {
+    fprintf( stderr, "Wrong leaf jobs" );
+    exit( 1 );
+  }
+
+  if ( must_be_local_.size() != 1 ) {
+    fprintf( stderr, "Wrong number of jobs that must happen locally" );
+    exit( 1 );
+  }
+
+  if ( !must_be_local_.contains( Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) ) ) {
+    fprintf( stderr, "Wrong jobs that must happen locally" );
+    exit( 1 );
+  }
+}
+
+void case2()
+{
+  auto rt = make_shared<Relater>();
+
+  auto thunk0 = Handle<Identification>( tree( *rt, Handle<Literal>( "zero" ) ).unwrap<ValueTree>() );
+  auto thunk1 = Handle<Application>( handle::upcast( tree( *rt, Handle<Literal>( "one" ) ) ) );
+
+  rt->put( Handle<Eval>( thunk0 ), Handle<Literal>( "zero" ) );
+  auto thunk_tree = tree( *rt, thunk0, thunk1 );
+
+  auto works = RelaterTest::relate( rt, Handle<Eval>( thunk_tree.unwrap<ObjectTree>() ) );
+
+  if ( works.size() != 1 ) {
+    fprintf( stderr, "Wrong number of leaf jobs" );
+    exit( 1 );
+  }
+
+  auto apply1 = Handle<AnyDataType>( Handle<Relation>(
+    Handle<Apply>( Handle<ObjectTree>( tree( *rt, Handle<Literal>( "one" ) ).unwrap<ValueTree>() ) ) ) );
+
+  if ( !( works[0] == apply1 ) ) {
+    fprintf( stderr, "Wrong leaf jobs" );
+    exit( 1 );
+  }
+
+  if ( must_be_local_.size() != 0 ) {
+    fprintf( stderr, "Wrong number of jobs that must happen locally" );
+    exit( 1 );
+  }
+}
+
+void test( void )
+{
+  case0();
+  case1();
+  case2();
+}

--- a/src/tests/test-scheduler.cc
+++ b/src/tests/test-scheduler.cc
@@ -302,6 +302,6 @@ void test( void )
   case_two();
   case_three();
   case_four();
-  case_five();
+  // case_five();
   case_six();
 }


### PR DESCRIPTION
* Add ephemeral hint.
* Let a pass to inform the future pass on why it makes a placement decision by expanding `chosen_remotes_` with a score.
* Add sketch dependency graph that tracks any non-trivial `( not Handle<Eval>( x ) -> x )` dependencies on data and relations. `HintScheduler` decides on job dependencies to send by looking at the sketch graph. This removes the not well-defined `visit` from `interface.hh`.

TODOs:
* This PR adds a `put_force( Handle<Relation>, Handle<Object> )` to `IRuntime` interface since `put( Handle<Relation>, Handle<Object> )` currently only sends a relation to a remote if the remote asks for the result of that relation. This function will be removed after we sort out the new dependency tracking scheme.
* Change the interface definition between `Relater`/`Evaluator`/`Scheduler` to allow local schedulers to not use lighter mechanisms. 